### PR TITLE
Fix: handle promise rejection and clear pending promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,9 +185,12 @@ class Cacheable<T> {
   async #fetch(resource: () => Promise<T>): Promise<T> {
     this.#lastFetch = Date.now()
     this.#promise = resource()
-    this.#value = await this.#promise
-    if (!this.#initialized) this.#initialized = true
-    this.#promise = undefined
+    try {
+      this.#value = await this.#promise
+      if (!this.#initialized) this.#initialized = true
+    } finally {
+      this.#promise = undefined
+    }
     return this.#value
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -189,4 +189,14 @@ describe('Cache operations', () => {
     }
     await expect(rejecting).rejects.toEqual(errorMessage)
   })
+
+  it("Doesn't cache rejected value", async () => {
+    const cache = new Cacheables()
+    let errNo = 1
+    const rejecting = () => {
+      return cache.cacheable(() => Promise.reject(errNo++), 'a')
+    }
+    await expect(rejecting()).rejects.toEqual(1)
+    await expect(rejecting()).rejects.toEqual(2)
+  })
 })


### PR DESCRIPTION
Relevant to #6 . When the `resource` function returns a rejected promise, the `#fetch` function throws immediately without clearing the `#promise` field. So in every calls of `#fetchNonConcurrent` later, it would go into the `isFetching` branch and throw the same error/rejected promise. 

The new test case illustrates its erroneous behaviour. Before the fix, the return value of `rejecting` function is 1 every time. 