### PR TITLE
Add concept of connectors to cacheables

### DIFF
--- a/src/connectors/memory_connector.ts
+++ b/src/connectors/memory_connector.ts
@@ -1,0 +1,25 @@
+import { Cacheable, CacheConnector } from '..'
+
+export default class MemoryConnector implements CacheConnector {
+  #cacheables: Record<string, Cacheable<any>> = {}
+
+  get(key: string): Cacheable<any> | undefined {
+    return this.#cacheables[key]
+  }
+
+  set(key: string, data: Cacheable<any>): void {
+    this.#cacheables[key] = data
+  }
+
+  delete(key: string): void {
+    delete this.#cacheables[key]
+  }
+
+  clear(): void {
+    this.#cacheables = {}
+  }
+
+  keys(): string[] {
+    return Object.keys(this.#cacheables)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ export type CacheOptions = {
    */
   logTiming?: boolean
   /**
-   * Enable/disable timings
+   * Provides an object that conforms to 
+   * CacheConnector to implement custom cache backends
    */
   cacheConnector?: CacheConnector
 }


### PR DESCRIPTION
This PR allows a custom cache connector to replace the in-memory cache. This PR retains the default behavior of the library (in-memory cache) but allows you to specify a connector that implements `CacheConnector`. This will allow users to implement databases such as Redis or other KV stores as cache storage.

The in-memory cache has been broken into its own class that implements `CacheConnector` to simplify the code. This class is used by default if a connector is not specified.