### PR TITLE
Move cache policy to instance and rename cacheable() to remember()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A simple in-memory cache with support of different cache policies and elegant sy
 fetch('https://some-url.com/api')
 
 // with caching
-cache.cacheable(() => fetch('https://some-url.com/api'), 'key')
+cache.remember(() => fetch('https://some-url.com/api'), 'key')
 ```
 
 * [Installation](#installation)
@@ -30,7 +30,7 @@ cache.cacheable(() => fetch('https://some-url.com/api'), 'key')
 * [Usage](#usage)
 * [API](#api)
   * [new Cacheables(options?): Cacheables](#new-cacheablesoptions-cacheables)
-  * [cache.cacheable(resource, key): Promise&lt;T&gt;](#cachecacheableresource-key-promiset)
+  * [cache.remember(resource, key): Promise&lt;T&gt;](#cacherememberresource-key-promiset)
   * [cache.delete(key: string): void](#cachedeletekey-string-void)
   * [cache.clear(): void](#cacheclear-void)
   * [cache.keys(): string[]](#cachekeys-string)
@@ -79,7 +79,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 // The method returns a fully typed Promise just like `fetch(apiUrl)`
 // would but with the benefit of caching the result.
 const getWeatherData = () =>
-  cache.cacheable(() => fetch(apiUrl), 'weather')
+  cache.remember(() => fetch(apiUrl), 'weather')
 
 const start = async () => {
   // Fetch some fresh weather data and store it in our cache.
@@ -103,9 +103,9 @@ const start = async () => {
 start()
 ```
 
-`cacheable` serves both as the getter and setter. This method will return a cached resource if available or use the provided argument `resource` to fill the cache and return a value.
+`remember` serves both as the getter and setter. This method will return a cached resource if available or use the provided argument `resource` to fill the cache and return a value.
 
-> Be aware that there is no exclusive cache getter (like `cache.get('key)`). This is by design as the Promise provided by the first argument to `cacheable` is used to infer the return type of the cached resource.
+> Be aware that there is no exclusive cache getter (like `cache.get('key)`). This is by design as the Promise provided by the first argument to `remember` is used to infer the return type of the cached resource.
 
 ## API
 
@@ -145,9 +145,9 @@ const cache = new Cacheables({
 })
 ```
 
-### `cache.cacheable(resource, key): Promise<T>`
+### `cache.remember(resource, key): Promise<T>`
 
-- If a resource exists in the cache (determined by the presence of a value with key `key`) `cacheable` decides on returning a cache based on the instance's cache policy.
+- If a resource exists in the cache (determined by the presence of a value with key `key`) `remember` decides on returning a cache based on the instance's cache policy.
 - If there's no resource in the cache, the provided `resource` will be called and used to store a cache value with key `key` and the value is returned.
 
 #### Arguments
@@ -166,7 +166,7 @@ See [Cacheables.key()](#cacheableskeyargs-string--number-string) for a safe and 
 ```ts
 const cache = new Cacheables({ policy: 'max-age', maxAge: 10000 })
 
-const cachedApiResponse = await cache.cacheable(
+const cachedApiResponse = await cache.remember(
   () => fetch('https://github.com/'),
   'key',
 )
@@ -241,7 +241,7 @@ If there is no cache yet, all calls will be resolved by the first network reques
 ##### Example
 ```ts
 const cache = new Cacheables({ policy: 'cache-only' })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ### Network Only
@@ -252,7 +252,7 @@ Simultaneous requests trigger simultaneous network requests.
 ##### Example
 ```ts
 const cache = new Cacheables({ policy: 'network-only' })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ### Network Only – Non Concurrent
@@ -263,7 +263,7 @@ All requests should be handled by the network but no concurrent network requests
 ##### Example
 ```ts
 const cache = new Cacheables({ policy: 'network-only-non-concurrent' })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ### Max Age
@@ -275,7 +275,7 @@ All requests should be checked against max-age. If max-age is expired, a network
 ```ts
 // Trigger a network request if the cached value is older than 1 second.
 const cache = new Cacheables({ policy: 'max-age', maxAge: 1000 })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ### Stale While Revalidate
@@ -286,14 +286,14 @@ The cache policy `stale-while-revalidate` will return a cached value immediately
 ```ts
 // If there is a cache, return it but 'silently' update the cache.
 const cache = new Cacheables({ policy: 'stale-while-revalidate' })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ##### Example with `maxAge`
 ```ts
 // If there is a cache, return it and 'silently' update the cache if it's older than 1 second.
 const cache = new Cacheables({ policy: 'stale-while-revalidate', maxAge: 1000 })
-cache.cacheable(() => fetch(url), 'a')
+cache.remember(() => fetch(url), 'a')
 ```
 
 ## In Progress

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cache.cacheable(() => fetch('https://some-url.com/api'), 'key')
 * [Usage](#usage)
 * [API](#api)
   * [new Cacheables(options?): Cacheables](#new-cacheablesoptions-cacheables)
-  * [cache.cacheable(resource, key, options?): Promise&lt;T&gt;](#cachecacheableresource-key-options-promiset)
+  * [cache.cacheable(resource, key): Promise&lt;T&gt;](#cachecacheableresource-key-promiset)
   * [cache.delete(key: string): void](#cachedeletekey-string-void)
   * [cache.clear(): void](#cacheclear-void)
   * [cache.keys(): string[]](#cachekeys-string)
@@ -42,7 +42,6 @@ cache.cacheable(() => fetch('https://some-url.com/api'), 'key')
   * [Network Only – Non Concurrent](#network-only--non-concurrent)
   * [Max Age](#max-age)
   * [Stale While Revalidate](#stale-while-revalidate)
-  * [Cache Policy Composition](#cache-policy-composition)
 * [In Progress](#in-progress)
 * [License](#license)
 
@@ -67,7 +66,9 @@ const apiUrl = "https://goweather.herokuapp.com/weather/Karlsruhe"
 // Create a new cache instance
 const cache = new Cacheables({
   logTiming: true,
-  log: true
+  log: true,
+  policy: 'max-age',
+  maxAge: 5000,
 })
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -78,10 +79,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 // The method returns a fully typed Promise just like `fetch(apiUrl)`
 // would but with the benefit of caching the result.
 const getWeatherData = () =>
-  cache.cacheable(() => fetch(apiUrl), 'weather', {
-    cachePolicy: 'max-age',
-    maxAge: 5000,
-  })
+  cache.cacheable(() => fetch(apiUrl), 'weather')
 
 const start = async () => {
   // Fetch some fresh weather data and store it in our cache.
@@ -120,12 +118,20 @@ start()
 ##### - `options?: CacheOptions`
 
 ```ts
-interface CacheOptions {
+type CacheOptions = {
   enabled?: boolean    // Enable/disable the cache, can be set anytime, default: true.
-  log?: boolean        // Log hits to the cache, default: false. 
+  log?: boolean        // Log hits to the cache, default: false.
   logTiming?: boolean  // Log the timing, default: false.
-}
+} & (
+  | { policy?: 'cache-only' }                                // default
+  | { policy: 'network-only' }
+  | { policy: 'network-only-non-concurrent' }
+  | { policy: 'max-age', maxAge: number }                    // maxAge required
+  | { policy: 'stale-while-revalidate', maxAge?: number }    // maxAge optional
+)
 ```
+
+The cache policy (and `maxAge` where applicable) is set on the instance and applies to every entry in that cache. To use multiple policies, create multiple `Cacheables` instances.
 
 #### Example:
 
@@ -133,13 +139,15 @@ interface CacheOptions {
 import { Cacheables } from 'cacheables'
 
 const cache = new Cacheables({
-  logTiming: true
+  logTiming: true,
+  policy: 'max-age',
+  maxAge: 5000,
 })
 ```
 
-### `cache.cacheable(resource, key, options?): Promise<T>`
+### `cache.cacheable(resource, key): Promise<T>`
 
-- If a resource exists in the cache (determined by the presence of a value with key `key`) `cacheable` decides on returning a cache based on the provided cache policy.
+- If a resource exists in the cache (determined by the presence of a value with key `key`) `cacheable` decides on returning a cache based on the instance's cache policy.
 - If there's no resource in the cache, the provided `resource` will be called and used to store a cache value with key `key` and the value is returned.
 
 #### Arguments
@@ -153,29 +161,14 @@ A function that returns a `Promise<T>`.
 A key to store the cache at.  
 See [Cacheables.key()](#cacheableskeyargs-string--number-string) for a safe and easy way to generate unique keys.
 
-##### - `options?: CacheableOptions` (optional)
-
-An object defining the cache policy and possibly other options in the future.
-The default cache policy is `cache-only`.
-See [Cache Policies](#cache-policies).
-
-```ts
-type CacheableOptions = {
-  cachePolicy: 'cache-only' | 'network-only-non-concurrent' | 'network-only' | 'max-age' | 'stale-while-revalidate' // See cache policies for details
-  maxAge?: number // Required if cache policy is `max-age` and optional if cache policy is `stale-while-revalidate`
-}
-```
-
 #### Example
 
 ```ts
+const cache = new Cacheables({ policy: 'max-age', maxAge: 10000 })
+
 const cachedApiResponse = await cache.cacheable(
   () => fetch('https://github.com/'),
   'key',
-  {
-    cachePolicy: 'max-age',
-    maxAge: 10000
-  }
 )
 ```
 
@@ -247,7 +240,8 @@ If there is no cache yet, all calls will be resolved by the first network reques
 
 ##### Example
 ```ts
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'cache-only' })
+const cache = new Cacheables({ policy: 'cache-only' })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ### Network Only
@@ -257,7 +251,8 @@ Simultaneous requests trigger simultaneous network requests.
 
 ##### Example
 ```ts
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'network-only' })
+const cache = new Cacheables({ policy: 'network-only' })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ### Network Only – Non Concurrent
@@ -267,7 +262,8 @@ All requests should be handled by the network but no concurrent network requests
 
 ##### Example
 ```ts
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'network-only-non-concurrent' })
+const cache = new Cacheables({ policy: 'network-only-non-concurrent' })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ### Max Age
@@ -278,10 +274,8 @@ All requests should be checked against max-age. If max-age is expired, a network
 ##### Example
 ```ts
 // Trigger a network request if the cached value is older than 1 second.
-cache.cacheable(() => fetch(url), 'a', { 
-  cachePolicy: 'max-age',
-  maxAge: 1000
-})
+const cache = new Cacheables({ policy: 'max-age', maxAge: 1000 })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ### Stale While Revalidate
@@ -291,28 +285,15 @@ The cache policy `stale-while-revalidate` will return a cached value immediately
 ##### Example without `maxAge`
 ```ts
 // If there is a cache, return it but 'silently' update the cache.
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'stale-while-revalidate'})
+const cache = new Cacheables({ policy: 'stale-while-revalidate' })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ##### Example with `maxAge`
 ```ts
 // If there is a cache, return it and 'silently' update the cache if it's older than 1 second.
-cache.cacheable(() => fetch(url), 'a', {
-  cachePolicy: 'stale-while-revalidate',
-  maxAge: 1000
-})
-```
-
-### Cache Policy Composition
-A single cacheable can be requested with different cache policies at any time.
-
-#### Example
-```ts
-// If there is a cache, return it.
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'cache-only' })
-
-// If there is a cache, return it but 'silently' update the cache.
-cache.cacheable(() => fetch(url), 'a', { cachePolicy: 'stale-while-revalidate' })
+const cache = new Cacheables({ policy: 'stale-while-revalidate', maxAge: 1000 })
+cache.cacheable(() => fetch(url), 'a')
 ```
 
 ## In Progress

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cacheables",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A simple in-memory cache written in Typescript with automatic cache invalidation and an elegant syntax.",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",
@@ -36,7 +36,7 @@
     "cache",
     "in-memory",
     "typescript",
-    "cacheable",
+    "remember",
     "cacheables"
   ],
   "author": "Grischa Erbe <grischa.erbe@googlemail.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,8 @@ export class Cacheables {
     this.logTiming = options?.logTiming ?? false
     this.#policy = options?.policy ?? 'cache-only'
     this.#maxAge =
-      options?.policy === 'max-age' || options?.policy === 'stale-while-revalidate'
+      options?.policy === 'max-age' ||
+      options?.policy === 'stale-while-revalidate'
         ? options.maxAge
         : undefined
   }
@@ -126,7 +127,7 @@ export class Cacheables {
    * @param resource A function returning a Promise
    * @param key A key to identify the cache
    * @example
-   * const apiResponse = await cache.cacheable(
+   * const apiResponse = await cache.remember(
    *   () => api.query({
    *     query: someQuery,
    *     variables: someVariables,
@@ -136,7 +137,7 @@ export class Cacheables {
    * @returns promise Resolves to the value of the provided resource, either from
    * cache or from the remote resource itself.
    */
-  async cacheable<T>(resource: () => Promise<T>, key: string): Promise<T> {
+  async remember<T>(resource: () => Promise<T>, key: string): Promise<T> {
     const shouldCache = this.enabled
     if (!shouldCache) {
       if (this.log) Logger.logDisabled()
@@ -148,7 +149,7 @@ export class Cacheables {
     const logId = Logger.getLogId(key)
     if (logTiming) Logger.logTime(logId)
 
-    const result = await this.#cacheable(resource, key)
+    const result = await this.#remember(resource, key)
 
     if (logTiming) Logger.logTimeEnd(logId)
     if (log) Logger.logStats(key, this.#cacheables[key])
@@ -156,7 +157,7 @@ export class Cacheables {
     return result
   }
 
-  #cacheable<T>(resource: () => Promise<T>, key: string): Promise<T> {
+  #remember<T>(resource: () => Promise<T>, key: string): Promise<T> {
     let cacheable = this.#cacheables[key] as Cacheable<T> | undefined
 
     if (!cacheable) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 //region Types
-export type CacheOptions = {
+type CacheOptionsBase = {
   /**
    * Enables caching
    */
@@ -14,37 +14,47 @@ export type CacheOptions = {
   logTiming?: boolean
 }
 
-type CacheOnlyCachePolicy = {
-  cachePolicy: 'cache-only'
+type CacheOnlyPolicy = {
+  policy?: 'cache-only'
 }
 
-type NetworkOnlyNonConcurrentCachePolicy = {
-  cachePolicy: 'network-only-non-concurrent'
+type NetworkOnlyPolicy = {
+  policy: 'network-only'
 }
 
-type NetworkOnlyCachePolicy = {
-  cachePolicy: 'network-only'
+type NetworkOnlyNonConcurrentPolicy = {
+  policy: 'network-only-non-concurrent'
 }
 
-type MaxAgeCachePolicy = {
-  cachePolicy: 'max-age'
+type MaxAgePolicy = {
+  policy: 'max-age'
   maxAge: number
 }
 
-type SWRCachePolicy = {
-  cachePolicy: 'stale-while-revalidate'
+type SWRPolicy = {
+  policy: 'stale-while-revalidate'
   maxAge?: number
 }
 
+type PolicyOptions =
+  | CacheOnlyPolicy
+  | NetworkOnlyPolicy
+  | NetworkOnlyNonConcurrentPolicy
+  | MaxAgePolicy
+  | SWRPolicy
+
 /**
- * Cacheable options.
+ * Cacheables options. Combines instance settings with the cache policy
+ * (and policy-specific options like `maxAge`).
  */
-export type CacheableOptions =
-  | CacheOnlyCachePolicy
-  | NetworkOnlyCachePolicy
-  | NetworkOnlyNonConcurrentCachePolicy
-  | MaxAgeCachePolicy
-  | SWRCachePolicy
+export type CacheOptions = CacheOptionsBase & PolicyOptions
+
+type Policy =
+  | 'cache-only'
+  | 'network-only'
+  | 'network-only-non-concurrent'
+  | 'max-age'
+  | 'stale-while-revalidate'
 
 //endregion
 
@@ -57,10 +67,18 @@ export class Cacheables {
   log: boolean
   logTiming: boolean
 
+  #policy: Policy
+  #maxAge: number | undefined
+
   constructor(options?: CacheOptions) {
     this.enabled = options?.enabled ?? true
     this.log = options?.log ?? false
     this.logTiming = options?.logTiming ?? false
+    this.#policy = options?.policy ?? 'cache-only'
+    this.#maxAge =
+      options?.policy === 'max-age' || options?.policy === 'stale-while-revalidate'
+        ? options.maxAge
+        : undefined
   }
 
   #cacheables: Record<string, Cacheable<any>> = {}
@@ -107,7 +125,6 @@ export class Cacheables {
    * that you want to cache for a certain period of time.
    * @param resource A function returning a Promise
    * @param key A key to identify the cache
-   * @param options {CacheableOptions} options
    * @example
    * const apiResponse = await cache.cacheable(
    *   () => api.query({
@@ -115,16 +132,11 @@ export class Cacheables {
    *     variables: someVariables,
    *   }),
    *   Cache.key('type', someCacheKey, someOtherCacheKey),
-   *   60000
    * )
    * @returns promise Resolves to the value of the provided resource, either from
    * cache or from the remote resource itself.
    */
-  async cacheable<T>(
-    resource: () => Promise<T>,
-    key: string,
-    options?: CacheableOptions,
-  ): Promise<T> {
+  async cacheable<T>(resource: () => Promise<T>, key: string): Promise<T> {
     const shouldCache = this.enabled
     if (!shouldCache) {
       if (this.log) Logger.logDisabled()
@@ -136,7 +148,7 @@ export class Cacheables {
     const logId = Logger.getLogId(key)
     if (logTiming) Logger.logTime(logId)
 
-    const result = await this.#cacheable(resource, key, options)
+    const result = await this.#cacheable(resource, key)
 
     if (logTiming) Logger.logTimeEnd(logId)
     if (log) Logger.logStats(key, this.#cacheables[key])
@@ -144,11 +156,7 @@ export class Cacheables {
     return result
   }
 
-  #cacheable<T>(
-    resource: () => Promise<T>,
-    key: string,
-    options?: CacheableOptions,
-  ): Promise<T> {
+  #cacheable<T>(resource: () => Promise<T>, key: string): Promise<T> {
     let cacheable = this.#cacheables[key] as Cacheable<T> | undefined
 
     if (!cacheable) {
@@ -156,7 +164,7 @@ export class Cacheables {
       this.#cacheables[key] = cacheable
     }
 
-    return cacheable.touch(resource, options)
+    return cacheable.touch(resource, this.#policy, this.#maxAge)
   }
 }
 //endregion
@@ -203,20 +211,13 @@ class Cacheable<T> {
     return this.#fetch(resource)
   }
 
-  #handlePreInit(
-    resource: () => Promise<T>,
-    options?: CacheableOptions,
-  ): Promise<T> {
-    if (!options) return this.#fetchNonConcurrent(resource)
-    switch (options.cachePolicy) {
-      case 'cache-only':
-        return this.#fetchNonConcurrent(resource)
+  #handlePreInit(resource: () => Promise<T>, policy: Policy): Promise<T> {
+    switch (policy) {
       case 'network-only':
         return this.#fetch(resource)
+      case 'cache-only':
       case 'stale-while-revalidate':
-        return this.#fetchNonConcurrent(resource)
       case 'max-age':
-        return this.#fetchNonConcurrent(resource)
       case 'network-only-non-concurrent':
         return this.#fetchNonConcurrent(resource)
     }
@@ -258,28 +259,24 @@ class Cacheable<T> {
    * Get and set the value of the Cacheable.
    * Some tricky race are conditions going on here,
    * but this should behave as expected
-   * @param resource
-   * @param options {CacheableOptions}
    */
   async touch(
     resource: () => Promise<T>,
-    options?: CacheableOptions,
+    policy: Policy,
+    maxAge: number | undefined,
   ): Promise<T> {
     if (!this.#initialized) {
-      return this.#handlePreInit(resource, options)
+      return this.#handlePreInit(resource, policy)
     }
-    if (!options) {
-      return this.#handleCacheOnly()
-    }
-    switch (options.cachePolicy) {
+    switch (policy) {
       case 'cache-only':
         return this.#handleCacheOnly()
       case 'network-only':
         return this.#handleNetworkOnly(resource)
       case 'stale-while-revalidate':
-        return this.#handleSwr(resource, options.maxAge)
+        return this.#handleSwr(resource, maxAge)
       case 'max-age':
-        return this.#handleMaxAge(resource, options.maxAge)
+        return this.#handleMaxAge(resource, maxAge as number)
       case 'network-only-non-concurrent':
         return this.#handleNetworkOnlyNonConcurrent(resource)
     }

--- a/tests/fetchPolicies.test.ts
+++ b/tests/fetchPolicies.test.ts
@@ -15,12 +15,10 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('Fetch Policies', () => {
   it('cache-only', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({ policy: 'cache-only' })
 
     const COCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v), 'key', {
-        cachePolicy: 'cache-only',
-      })
+      cache.cacheable(() => mockedApiRequest(v), 'key')
 
     const a = await COCacheable(0)
     const b = await COCacheable(1)
@@ -32,12 +30,10 @@ describe('Fetch Policies', () => {
   })
 
   it('network-only-non-concurrent', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({ policy: 'network-only-non-concurrent' })
 
     const NONCCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key', {
-        cachePolicy: 'network-only-non-concurrent',
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
     await NONCCacheable(-1)
@@ -55,12 +51,10 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 0, 0, 3])
   })
   it('network-only', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({ policy: 'network-only' })
 
     const NOCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key', {
-        cachePolicy: 'network-only',
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
     await NOCacheable(-1)
@@ -74,13 +68,10 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 1, 2])
   })
   it('max-age', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({ policy: 'max-age', maxAge: 100 })
 
     const MACacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key', {
-        cachePolicy: 'max-age',
-        maxAge: 100,
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
 
     const a = await MACacheable(0)
     const b = await MACacheable(1)
@@ -93,12 +84,10 @@ describe('Fetch Policies', () => {
     expect([a, b, c, d]).toEqual([0, 0, 2, 2])
   })
   it('stale-while-revalidate', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({ policy: 'stale-while-revalidate' })
 
     const SWRCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key', {
-        cachePolicy: 'stale-while-revalidate',
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
     await SWRCacheable(-1)
@@ -119,13 +108,13 @@ describe('Fetch Policies', () => {
   })
 
   it('stale-while-revalidate with maxAge', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({
+      policy: 'stale-while-revalidate',
+      maxAge: 200,
+    })
 
     const SWRCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key', {
-        cachePolicy: 'stale-while-revalidate',
-        maxAge: 200,
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache, takes ~50ms
     await SWRCacheable(0)

--- a/tests/fetchPolicies.test.ts
+++ b/tests/fetchPolicies.test.ts
@@ -17,12 +17,12 @@ describe('Fetch Policies', () => {
   it('cache-only', async () => {
     const cache = new Cacheables({ policy: 'cache-only' })
 
-    const COCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v), 'key')
+    const co = (v: any) =>
+      cache.remember(() => mockedApiRequest(v), 'key')
 
-    const a = await COCacheable(0)
-    const b = await COCacheable(1)
-    const c = await COCacheable(2)
+    const a = await co(0)
+    const b = await co(1)
+    const c = await co(2)
 
     expect(a).toEqual(0)
     expect(b).toEqual(0)
@@ -32,19 +32,19 @@ describe('Fetch Policies', () => {
   it('network-only-non-concurrent', async () => {
     const cache = new Cacheables({ policy: 'network-only-non-concurrent' })
 
-    const NONCCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
+    const nonc = (v: any) =>
+      cache.remember(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
-    await NONCCacheable(-1)
+    await nonc(-1)
 
-    const a = NONCCacheable(0)
-    const b = NONCCacheable(1)
-    const c = NONCCacheable(2)
+    const a = nonc(0)
+    const b = nonc(1)
+    const c = nonc(2)
 
     await wait(100)
 
-    const d = NONCCacheable(3)
+    const d = nonc(3)
 
     const values = await Promise.all([a, b, c, d])
 
@@ -53,15 +53,15 @@ describe('Fetch Policies', () => {
   it('network-only', async () => {
     const cache = new Cacheables({ policy: 'network-only' })
 
-    const NOCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
+    const no = (v: any) =>
+      cache.remember(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
-    await NOCacheable(-1)
+    await no(-1)
 
-    const a = NOCacheable(0)
-    const b = NOCacheable(1)
-    const c = NOCacheable(2)
+    const a = no(0)
+    const b = no(1)
+    const c = no(2)
 
     const values = await Promise.all([a, b, c])
 
@@ -70,39 +70,39 @@ describe('Fetch Policies', () => {
   it('max-age', async () => {
     const cache = new Cacheables({ policy: 'max-age', maxAge: 100 })
 
-    const MACacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
+    const ma = (v: any) =>
+      cache.remember(() => mockedApiRequest(v, 50), 'key')
 
-    const a = await MACacheable(0)
-    const b = await MACacheable(1)
+    const a = await ma(0)
+    const b = await ma(1)
 
     await wait(100)
 
-    const c = await MACacheable(2)
-    const d = await MACacheable(3)
+    const c = await ma(2)
+    const d = await ma(3)
 
     expect([a, b, c, d]).toEqual([0, 0, 2, 2])
   })
   it('stale-while-revalidate', async () => {
     const cache = new Cacheables({ policy: 'stale-while-revalidate' })
 
-    const SWRCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
+    const swr = (v: any) =>
+      cache.remember(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache
-    await SWRCacheable(-1)
+    await swr(-1)
 
     await wait(100)
 
-    const a = await SWRCacheable(0)
-    const b = await SWRCacheable(1)
-    const c = await SWRCacheable(2)
+    const a = await swr(0)
+    const b = await swr(1)
+    const c = await swr(2)
 
     await wait(100)
 
-    const d = await SWRCacheable(3)
-    const e = await SWRCacheable(4)
-    const f = await SWRCacheable(5)
+    const d = await swr(3)
+    const e = await swr(4)
+    const f = await swr(5)
 
     expect([a, b, c, d, e, f]).toEqual([-1, -1, -1, 0, 0, 0])
   })
@@ -113,26 +113,26 @@ describe('Fetch Policies', () => {
       maxAge: 200,
     })
 
-    const SWRCacheable = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'key')
+    const swr = (v: any) =>
+      cache.remember(() => mockedApiRequest(v, 50), 'key')
 
     // Preheat cache, takes ~50ms
-    await SWRCacheable(0)
+    await swr(0)
 
     await wait(100)
 
     // ~150ms on the clock, maxAge not reached
-    const a = await SWRCacheable(1)
+    const a = await swr(1)
 
     await wait(100)
 
     // ~250ms on the clock, maxAge reached, cache updates silently
-    const b = await SWRCacheable(2)
+    const b = await swr(2)
 
     await wait(100)
 
     // ~350ms on the clock, cache should be updated silently with value `2`
-    const c = await SWRCacheable(3)
+    const c = await swr(3)
 
     expect([a, b, c]).toEqual([0, 0, 2])
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -24,7 +24,7 @@ describe('Cache operations', () => {
   it('Returns correct values', async () => {
     const cache = new Cacheables()
     const value = 10
-    const cachedValue = await cache.cacheable(
+    const cachedValue = await cache.remember(
       () => mockedApiRequest(value),
       'a',
     )
@@ -39,11 +39,11 @@ describe('Cache operations', () => {
     const valueA = 10
     const valueB = 20
 
-    const cachedValueA = await cache.cacheable(
+    const cachedValueA = await cache.remember(
       () => mockedApiRequest(valueA),
       'a',
     )
-    const cachedValueB = await cache.cacheable(
+    const cachedValueB = await cache.remember(
       () => mockedApiRequest(valueB),
       'b',
     )
@@ -56,7 +56,7 @@ describe('Cache operations', () => {
     const cache = new Cacheables()
 
     const value = 10
-    await cache.cacheable(() => mockedApiRequest(value), 'a')
+    await cache.remember(() => mockedApiRequest(value), 'a')
 
     expect(cache.isCached('a')).toEqual(true)
     cache.delete('a')
@@ -67,7 +67,7 @@ describe('Cache operations', () => {
     const cache = new Cacheables()
 
     const value = 10
-    await cache.cacheable(() => mockedApiRequest(value), 'a')
+    await cache.remember(() => mockedApiRequest(value), 'a')
 
     expect(cache.isCached('a')).toEqual(true)
     cache.clear()
@@ -85,7 +85,7 @@ describe('Cache operations', () => {
     })
 
     const value = 10
-    const uncachedValue = await cache.cacheable(
+    const uncachedValue = await cache.remember(
       () => mockedApiRequest(value),
       'a',
     )
@@ -101,7 +101,7 @@ describe('Cache operations', () => {
       enabled: false,
     })
 
-    const cachedRequest = () => cache.cacheable(() => mockedApiRequest(1), 'a')
+    const cachedRequest = () => cache.remember(() => mockedApiRequest(1), 'a')
 
     await cachedRequest()
     expect(console.log).lastCalledWith('CACHE: Caching disabled')
@@ -128,7 +128,7 @@ describe('Cache operations', () => {
     })
 
     const racingCache = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'a')
+      cache.remember(() => mockedApiRequest(v, 50), 'a')
 
     // Create a cache that times out at 100 and resolves at 50
     const a = await racingCache('a')
@@ -157,7 +157,7 @@ describe('Cache operations', () => {
     })
 
     const hitCache = async () => {
-      await cache.cacheable(() => mockedApiRequest(0, 10), 'a')
+      await cache.remember(() => mockedApiRequest(0, 10), 'a')
     }
 
     // This should be a miss and take ~10ms
@@ -184,7 +184,7 @@ describe('Cache operations', () => {
   it("Doesn't interfere with error handling", async () => {
     const cache = new Cacheables()
     const rejecting = () => {
-      return cache.cacheable(() => mockedApiRequest(0, 10, true), 'a')
+      return cache.remember(() => mockedApiRequest(0, 10, true), 'a')
     }
     await expect(rejecting).rejects.toEqual(errorMessage)
   })
@@ -193,7 +193,7 @@ describe('Cache operations', () => {
     const cache = new Cacheables()
     let errNo = 1
     const rejecting = () => {
-      return cache.cacheable(() => Promise.reject(errNo++), 'a')
+      return cache.remember(() => Promise.reject(errNo++), 'a')
     }
     await expect(rejecting()).rejects.toEqual(1)
     await expect(rejecting()).rejects.toEqual(2)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { CacheableOptions, Cacheables } from '../src'
+import { Cacheables } from '../src'
 
 const errorMessage = 'This is an error message.'
 
@@ -122,13 +122,13 @@ describe('Cache operations', () => {
    * Assuming the time starts at 0
    */
   it('Handles race conditions correctly', async () => {
-    const cache = new Cacheables()
+    const cache = new Cacheables({
+      policy: 'max-age',
+      maxAge: 100,
+    })
 
     const racingCache = (v: any) =>
-      cache.cacheable(() => mockedApiRequest(v, 50), 'a', {
-        cachePolicy: 'max-age',
-        maxAge: 100,
-      })
+      cache.cacheable(() => mockedApiRequest(v, 50), 'a')
 
     // Create a cache that times out at 100 and resolves at 50
     const a = await racingCache('a')
@@ -152,13 +152,12 @@ describe('Cache operations', () => {
 
     const cache = new Cacheables({
       log: true,
+      policy: 'max-age',
+      maxAge: 100,
     })
 
     const hitCache = async () => {
-      await cache.cacheable(() => mockedApiRequest(0, 10), 'a', {
-        cachePolicy: 'max-age',
-        maxAge: 100,
-      })
+      await cache.cacheable(() => mockedApiRequest(0, 10), 'a')
     }
 
     // This should be a miss and take ~10ms


### PR DESCRIPTION
## Summary
- Move cache policy configuration from per-entry to per-instance (set on `new Cacheables({ policy, maxAge })`)
- Rename `cache.cacheable()` to `cache.remember()` for clearer semantics
- Bump major version to 3.0.0 (breaking API changes)

## Test plan
- [x] `tests/index.test.ts` updated and passing
- [x] `tests/fetchPolicies.test.ts` updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)