### PR TITLE
Rename Cacheables to Cacheable; storage adapters to buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,40 +4,39 @@
 ![Language](https://img.shields.io/github/languages/top/grischaerbe/cacheables)
 ![Build](https://img.shields.io/github/workflow/status/grischaerbe/cacheables/Node.js%20Package)
 
-A small, typed cache with composable storage adapters and a handful of cache policies, written in TypeScript.
+A small, typed cache with composable storage buckets and a handful of cache policies, written in TypeScript.
 
 - Elegant syntax: **wrap existing async calls** with `cache.remember(...)`.
 - **Multilayer storage**: compose a fast in-memory L1 with any L2 you write (filesystem, Redis, S3, …). Reads cascade L1 → Ln; on any hit the engine fills missing layers.
 - **Fully typed results**, including a generic `TMeta` parameter for sidecar metadata.
 - Supports different **cache policies**.
 - Helper to build cache keys.
-- Optional **namespace** prefix so multiple instances can share an adapter without collisions.
+- Optional **namespace** prefix so multiple instances can share a bucket without collisions.
 - Works in the browser and Node.js.
 - **No dependencies**.
 
 ```ts
-import { Cacheables, MemoryAdapter } from 'cacheables'
+import { Cacheable, MemoryBucket } from 'cacheables'
 
-const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+const cache = new Cacheable({ buckets: [new MemoryBucket()] })
 
 cache.remember(() => fetch('https://some-url.com/api'), 'key')
 ```
 
 * [Installation](#installation)
-* [Quickstart](#quickstart)
 * [Usage](#usage)
 * [API](#api)
-  * [new Cacheables(options)](#new-cacheablesoptions-cacheablestmeta)
+  * [new Cacheable(options)](#new-cacheableoptions-cacheabletmeta)
   * [cache.remember(resource, key)](#cacherememberresource-key-promiset)
   * [cache.delete(key)](#cachedeletekey-promisevoid)
   * [cache.clear()](#cacheclear-promisevoid)
   * [cache.isCached(key)](#cacheiscachedkey-promiseboolean)
   * [cache.meta(key)](#cachemetakey-promisetmeta--undefined)
-  * [Cacheables.key(...args)](#cacheableskeyargs-string)
-* [Storage adapters](#storage-adapters)
-  * [`IStorageAdapter` contract](#istorageadapter-contract)
-  * [Built-in `MemoryAdapter`](#built-in-memoryadapter)
-  * [Writing your own adapter](#writing-your-own-adapter)
+  * [Cacheable.key(...args)](#cacheablekeyargs-string)
+* [Buckets](#buckets)
+  * [`IBucket` contract](#ibucket-contract)
+  * [Built-in `MemoryBucket`](#built-in-memorybucket)
+  * [Writing your own bucket](#writing-your-own-bucket)
   * [Cascade behavior](#cascade-behavior)
   * [Typed metadata (`TMeta`)](#typed-metadata-tmeta)
 * [Namespacing](#namespacing)
@@ -54,12 +53,12 @@ npm install cacheables
 ## Usage
 
 ```ts
-import { Cacheables, MemoryAdapter } from 'cacheables'
+import { Cacheable, MemoryBucket } from 'cacheables'
 
 const apiUrl = 'https://goweather.herokuapp.com/weather/Karlsruhe'
 
-const cache = new Cacheables({
-  adapters: [new MemoryAdapter()],
+const cache = new Cacheable({
+  buckets: [new MemoryBucket()],
   policy: 'max-age',
   maxAge: 5_000,
 })
@@ -70,16 +69,16 @@ await getWeather() // miss — fetched
 await getWeather() // hit — cached
 ```
 
-`remember` is both getter and setter. The first time a key is requested it calls the resource and stores the result in every configured adapter; subsequent reads cascade through the adapters until one returns a hit.
+`remember` is both getter and setter. The first time a key is requested it calls the resource and stores the result in every configured bucket; subsequent reads cascade through the buckets until one returns a hit.
 
 ## API
 
-### `new Cacheables(options): Cacheables<TMeta>`
+### `new Cacheable(options): Cacheable<TMeta>`
 
 ```ts
-type CacheablesOptions<TMeta extends IBaseMeta = IBaseMeta> = {
-  adapters: IStorageAdapter<TMeta>[]   // REQUIRED, L1 first
-  namespace?: string                   // adapter keys become `${namespace}:${key}`
+type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> = {
+  buckets: IBucket<TMeta>[]            // REQUIRED, L1 first
+  namespace?: string                   // bucket keys become `${namespace}:${key}`
   enabled?: boolean                    // default: true
   log?: boolean                        // default: false
   logTiming?: boolean                  // default: false
@@ -92,19 +91,19 @@ type CacheablesOptions<TMeta extends IBaseMeta = IBaseMeta> = {
 )
 ```
 
-`adapters` must be a non-empty array; the constructor throws `Error('At least one storage adapter is required')` otherwise. The first adapter is L1 (fastest, queried first); the rest form deeper layers.
+`buckets` must be a non-empty array; the constructor throws `Error('At least one bucket is required')` otherwise. The first bucket is L1 (fastest, queried first); the rest form deeper layers.
 
 ### `cache.remember(resource, key): Promise<T>`
 
-Resolves to the cached value if present (subject to policy), otherwise calls `resource()` and stores the result in every adapter.
+Resolves to the cached value if present (subject to policy), otherwise calls `resource()` and stores the result in every bucket.
 
 ### `cache.delete(key): Promise<void>`
 
-Deletes the entry from every adapter.
+Deletes the entry from every bucket.
 
 ### `cache.clear(): Promise<void>`
 
-Clears every adapter and the in-flight registry.
+Clears every bucket and the in-flight registry.
 
 ### `cache.isCached(key): Promise<boolean>`
 
@@ -114,24 +113,26 @@ Clears every adapter and the in-flight registry.
 
 Returns the meta from the highest-priority layer that has the key — useful for inspecting sidecar fields like `etag`, `ttl`, etc.
 
-### `Cacheables.key(...args): string`
+### `Cacheable.key(...args): string`
 
 Joins the parts with `:`. Identical to v3.
 
 ```ts
-Cacheables.key('user', 42) // 'user:42'
+Cacheable.key('user', 42) // 'user:42'
 ```
 
-## Storage adapters
+## Buckets
 
-### `IStorageAdapter` contract
+A bucket is a single storage tier — memory, Redis, disk, S3, anything you can read and write by key. A `Cacheable` instance holds an ordered list of buckets and cascades reads and writes across them.
+
+### `IBucket` contract
 
 ```ts
 interface IBaseMeta {
   storedAt: number
 }
 
-interface IStorageAdapter<TMeta extends IBaseMeta = IBaseMeta> {
+interface IBucket<TMeta extends IBaseMeta = IBaseMeta> {
   read<T>(key: string): Promise<{ value: T } | undefined>
   write<T>(key: string, value: T, meta?: TMeta): Promise<void>
   meta(key: string): Promise<TMeta | undefined>
@@ -143,30 +144,30 @@ interface IStorageAdapter<TMeta extends IBaseMeta = IBaseMeta> {
 Rules:
 
 - `meta` MUST be cheap. The engine probes it on every layer for every read.
-- `read` returns `undefined` when the entry is absent and `{ value }` when it's present — the wrapper exists so adapters can store entries whose value is itself `undefined` without colliding with the absence signal.
-- When `write` receives a `meta`, the adapter MUST persist `meta.storedAt` verbatim (other fields MAY be transformed). This guarantees `max-age` semantics stay coherent across layers.
-- When `write` is called with no `meta`, the adapter MUST synthesize one with `storedAt: Date.now()`.
-- `clear` MUST remove every entry the adapter manages.
-- Any throw from any adapter rejects the surrounding `remember()` call. There is no per-adapter error suppression.
+- `read` returns `undefined` when the entry is absent and `{ value }` when it's present — the wrapper exists so buckets can store entries whose value is itself `undefined` without colliding with the absence signal.
+- When `write` receives a `meta`, the bucket MUST persist `meta.storedAt` verbatim (other fields MAY be transformed). This guarantees `max-age` semantics stay coherent across layers.
+- When `write` is called with no `meta`, the bucket MUST synthesize one with `storedAt: Date.now()`.
+- `clear` MUST remove every entry the bucket manages.
+- Any throw from any bucket rejects the surrounding `remember()` call. There is no per-bucket error suppression.
 
-### Built-in `MemoryAdapter`
+### Built-in `MemoryBucket`
 
 Ships with the package; covers the common in-memory use case.
 
 ```ts
-import { Cacheables, MemoryAdapter } from 'cacheables'
+import { Cacheable, MemoryBucket } from 'cacheables'
 
-const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+const cache = new Cacheable({ buckets: [new MemoryBucket()] })
 ```
 
-### Writing your own adapter
+### Writing your own bucket
 
-Implement `IStorageAdapter`. The contract is small enough that filesystem, Redis, IndexedDB, or S3 layers are easy to add without ceremony. A typical L2 keeps a sidecar (file, table, key/value entry) so `meta()` is cheap.
+Implement `IBucket`. The contract is small enough that filesystem, Redis, IndexedDB, or S3 buckets are easy to add without ceremony. A typical L2 keeps a sidecar (file, table, key/value entry) so `meta()` is cheap.
 
 ```ts
-import type { IStorageAdapter, IBaseMeta } from 'cacheables'
+import type { IBucket, IBaseMeta } from 'cacheables'
 
-class FileSystemAdapter implements IStorageAdapter {
+class FileSystemBucket implements IBucket {
   async read<T>(key: string): Promise<{ value: T } | undefined> { /* … */ }
   async write<T>(key: string, value: T, meta?: IBaseMeta): Promise<void> { /* … */ }
   async meta(key: string): Promise<IBaseMeta | undefined> { /* … */ }
@@ -178,8 +179,8 @@ class FileSystemAdapter implements IStorageAdapter {
 ### Cascade behavior
 
 ```ts
-const cache = new Cacheables({
-  adapters: [new MemoryAdapter(), new FileSystemAdapter()],
+const cache = new Cacheable({
+  buckets: [new MemoryBucket(), new FileSystemBucket()],
   policy: 'max-age',
   maxAge: 60_000,
 })
@@ -191,39 +192,39 @@ const cache = new Cacheables({
 
 ### Typed metadata (`TMeta`)
 
-`Cacheables` is generic in `TMeta`. Extend it to carry sidecar fields:
+`Cacheable` is generic in `TMeta`. Extend it to carry sidecar fields:
 
 ```ts
-import { Cacheables, type IBaseMeta, type IStorageAdapter } from 'cacheables'
+import { Cacheable, type IBaseMeta, type IBucket } from 'cacheables'
 
 interface ETagMeta extends IBaseMeta {
   etag: string
 }
 
-class ETagAdapter implements IStorageAdapter<ETagMeta> {
+class ETagBucket implements IBucket<ETagMeta> {
   // read / write / meta / delete / clear …
 }
 
-const cache = new Cacheables<ETagMeta>({
-  adapters: [new ETagAdapter()],
+const cache = new Cacheable<ETagMeta>({
+  buckets: [new ETagBucket()],
 })
 
 const meta = await cache.meta('user:42') // typed as ETagMeta | undefined
 ```
 
-Every adapter passed to the constructor must satisfy `IStorageAdapter<ETagMeta>`, and the TypeScript compiler enforces it. The built-in `MemoryAdapter` only implements `IStorageAdapter<IBaseMeta>`, so it can't be used in a `Cacheables` instance with a custom `TMeta` — write a custom adapter (or wrap `MemoryAdapter`) when you need extended metadata.
+Every bucket passed to the constructor must satisfy `IBucket<ETagMeta>`, and the TypeScript compiler enforces it. The built-in `MemoryBucket` only implements `IBucket<IBaseMeta>`, so it can't be used in a `Cacheable` instance with a custom `TMeta` — write a custom bucket (or wrap `MemoryBucket`) when you need extended metadata.
 
 ## Namespacing
 
-Set `namespace` and every adapter call sees keys prefixed with `${namespace}:`:
+Set `namespace` and every bucket call sees keys prefixed with `${namespace}:`:
 
 ```ts
-const adapter = new MemoryAdapter()
-const tenantA = new Cacheables({ adapters: [adapter], namespace: 'tenant-a' })
-const tenantB = new Cacheables({ adapters: [adapter], namespace: 'tenant-b' })
+const bucket = new MemoryBucket()
+const tenantA = new Cacheable({ buckets: [bucket], namespace: 'tenant-a' })
+const tenantB = new Cacheable({ buckets: [bucket], namespace: 'tenant-b' })
 ```
 
-Two instances can share an adapter without colliding. `delete` and `isCached` respect the namespace; `clear()` wipes the entire underlying adapter (it has no notion of which keys belong to which namespace), so reach for it only when you really mean *everything*.
+Two instances can share a bucket without colliding. `delete` and `isCached` respect the namespace; `clear()` wipes the entire underlying bucket (it has no notion of which keys belong to which namespace), so reach for it only when you really mean *everything*.
 
 ## Cache Policies
 
@@ -236,21 +237,25 @@ Two instances can share an adapter without colliding. `delete` and `isCached` re
 | `stale-while-revalidate`        | Return the cached value immediately; if `maxAge` is unset or exceeded, fire a background revalidation.                                                                                                                                                                                                 |
 
 ```ts
-new Cacheables({ adapters: [new MemoryAdapter()], policy: 'max-age', maxAge: 1_000 })
+new Cacheable({ buckets: [new MemoryBucket()], policy: 'max-age', maxAge: 1_000 })
 ```
 
 ## Migrating from v3 → v4
 
 Breaking changes:
 
-- `adapters` is now a **required** constructor option. `new Cacheables()` no longer compiles. Pass at least one adapter, e.g. `new Cacheables({ adapters: [new MemoryAdapter()] })`.
+- The class `Cacheables` has been renamed to `Cacheable`. Update imports and `new Cacheables(...)` call sites.
+- The `IStorageAdapter` interface has been renamed to `IBucket`, and `MemoryAdapter` to `MemoryBucket`. The contract is unchanged.
+- `buckets` is now a **required** constructor option (replaces the v3-style implicit memory store, and renamed from `adapters`). `new Cacheable()` no longer compiles. Pass at least one bucket, e.g. `new Cacheable({ buckets: [new MemoryBucket()] })`.
+- The constructor's empty-buckets error message is now `'At least one bucket is required'` (was `'At least one storage adapter is required'`).
+- The `CacheablesOptions` type has been renamed to `CacheableOptions`.
 - `delete(key)` returns `Promise<void>` (was `void`). Add `await`.
 - `clear()` returns `Promise<void>` (was `void`). Add `await`.
 - `isCached(key)` returns `Promise<boolean>` (was `boolean`). Add `await`.
 - `keys()` is **removed**. Enumerating heterogeneous async layers (some non-enumerable, like CDNs) doesn't have a single sensible semantic.
-- `Cacheables` is now generic in `TMeta`. Plain `new Cacheables({ adapters })` defaults to `Cacheables<IBaseMeta>` and is source-compatible at the type level.
-- New constructor options: `adapters` (required) and `namespace` (optional).
-- Any throw from any adapter rejects `remember()`. Previously the in-memory store couldn't fail; this is new strict-error surface for users with custom adapters.
+- `Cacheable` is now generic in `TMeta`. Plain `new Cacheable({ buckets })` defaults to `Cacheable<IBaseMeta>` and is source-compatible at the type level.
+- New constructor options: `buckets` (required) and `namespace` (optional).
+- Any throw from any bucket rejects `remember()`. Previously the in-memory store couldn't fail; this is new strict-error surface for users with custom buckets.
 
 ## License
 

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -1,28 +1,28 @@
 import { Logger } from './Logger'
 import type {
-  CacheablesOptions,
+  CacheableOptions,
   IBaseMeta,
-  IStorageAdapter,
+  IBucket,
   Policy,
 } from './types'
 
-export class Cacheables<TMeta extends IBaseMeta = IBaseMeta> {
+export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
   enabled: boolean
   log: boolean
   logTiming: boolean
 
   #policy: Policy
   #maxAge: number | undefined
-  #adapters: IStorageAdapter<TMeta>[]
+  #buckets: IBucket<TMeta>[]
   #namespace: string | undefined
   #inflight = new Map<string, Promise<unknown>>()
   #hits = new Map<string, number>()
 
-  constructor(options: CacheablesOptions<TMeta>) {
-    if (!options.adapters || options.adapters.length === 0) {
-      throw new Error('At least one storage adapter is required')
+  constructor(options: CacheableOptions<TMeta>) {
+    if (!options.buckets || options.buckets.length === 0) {
+      throw new Error('At least one bucket is required')
     }
-    this.#adapters = options.adapters
+    this.#buckets = options.buckets
     this.#namespace = options.namespace
     this.enabled = options.enabled ?? true
     this.log = options.log ?? false
@@ -46,13 +46,13 @@ export class Cacheables<TMeta extends IBaseMeta = IBaseMeta> {
   async delete(key: string): Promise<void> {
     const fullKey = this.#fullKey(key)
     this.#hits.delete(fullKey)
-    await Promise.all(this.#adapters.map((a) => a.delete(fullKey)))
+    await Promise.all(this.#buckets.map((b) => b.delete(fullKey)))
   }
 
   async clear(): Promise<void> {
     this.#inflight.clear()
     this.#hits.clear()
-    await Promise.all(this.#adapters.map((a) => a.clear()))
+    await Promise.all(this.#buckets.map((b) => b.clear()))
   }
 
   async isCached(key: string): Promise<boolean> {
@@ -175,7 +175,7 @@ export class Cacheables<TMeta extends IBaseMeta = IBaseMeta> {
   }
 
   async #cascadeProbe(fullKey: string): Promise<(TMeta | undefined)[]> {
-    return Promise.all(this.#adapters.map((a) => a.meta(fullKey)))
+    return Promise.all(this.#buckets.map((b) => b.meta(fullKey)))
   }
 
   async #cascadeRead<T>(
@@ -188,8 +188,8 @@ export class Cacheables<TMeta extends IBaseMeta = IBaseMeta> {
     )
     if (hitIdx === -1) return undefined
 
-    const adapter = this.#adapters[hitIdx]!
-    const result = await adapter.read<T>(fullKey)
+    const bucket = this.#buckets[hitIdx]!
+    const result = await bucket.read<T>(fullKey)
     if (result === undefined) return undefined
 
     const value = result.value
@@ -206,23 +206,23 @@ export class Cacheables<TMeta extends IBaseMeta = IBaseMeta> {
     hitIdx: number,
   ): Promise<void> {
     const writes: Promise<void>[] = []
-    for (let i = 0; i < this.#adapters.length; i++) {
+    for (let i = 0; i < this.#buckets.length; i++) {
       if (i === hitIdx) continue
       if (probes[i] !== undefined) continue
-      writes.push(this.#adapters[i]!.write(fullKey, value, hitMeta))
+      writes.push(this.#buckets[i]!.write(fullKey, value, hitMeta))
     }
     if (writes.length > 0) await Promise.all(writes)
   }
 
   async #cascadeWrite<T>(fullKey: string, value: T): Promise<void> {
-    const [l1, ...rest] = this.#adapters
+    const [l1, ...rest] = this.#buckets
     if (l1 === undefined) return
     await l1.write(fullKey, value)
     if (rest.length === 0) return
     const meta = await l1.meta(fullKey)
     if (meta === undefined) {
-      throw new Error('L1 adapter did not persist meta after write')
+      throw new Error('L1 bucket did not persist meta after write')
     }
-    await Promise.all(rest.map((a) => a.write(fullKey, value, meta)))
+    await Promise.all(rest.map((b) => b.write(fullKey, value, meta)))
   }
 }

--- a/src/buckets/MemoryBucket.ts
+++ b/src/buckets/MemoryBucket.ts
@@ -1,6 +1,6 @@
-import type { IBaseMeta, IStorageAdapter } from '../types'
+import type { IBaseMeta, IBucket } from '../types'
 
-export class MemoryAdapter implements IStorageAdapter<IBaseMeta> {
+export class MemoryBucket implements IBucket<IBaseMeta> {
   #store = new Map<string, { value: unknown; meta: IBaseMeta }>()
 
   async read<T>(key: string): Promise<{ value: T } | undefined> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-export { Cacheables } from './Cacheables'
-export { MemoryAdapter } from './adapters/MemoryAdapter'
+export { Cacheable } from './Cacheable'
+export { MemoryBucket } from './buckets/MemoryBucket'
 export type {
   CacheOptions,
-  CacheablesOptions,
+  CacheableOptions,
   IBaseMeta,
-  IStorageAdapter,
+  IBucket,
 } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,33 +1,33 @@
 /**
- * Base shape for all adapter metadata. Adapters MAY extend this with
+ * Base shape for all bucket metadata. Buckets MAY extend this with
  * additional sidecar fields (etag, ttl, version, etc.) provided their
- * extension is captured by the `TMeta` generic of `Cacheables`.
+ * extension is captured by the `TMeta` generic of `Cacheable`.
  */
 export interface IBaseMeta {
   storedAt: number
 }
 
 /**
- * Storage adapter contract. Adapters back layers (L1, L2, ...) of a
- * `Cacheables` instance. Reads cascade L1 → Ln; on any hit the engine
+ * Bucket contract. Buckets back the layers (L1, L2, ...) of a
+ * `Cacheable` instance. Reads cascade L1 → Ln; on any hit the engine
  * fills missing layers with the hit value preserving `meta.storedAt`.
  *
  * Contracts:
  * - `meta` MUST be cheap (engine probes it on every layer per read).
  * - `read` returns `undefined` when the entry is absent and `{ value }`
- *   when present — the wrapper exists so adapters can store entries
+ *   when present — the wrapper exists so buckets can store entries
  *   whose value is itself `undefined` without colliding with the
  *   absence signal.
- * - When `write` receives a `meta`, the adapter MUST persist
+ * - When `write` receives a `meta`, the bucket MUST persist
  *   `meta.storedAt` verbatim. Other fields MAY be transformed.
- * - When `write` receives no `meta`, the adapter MUST synthesize one
+ * - When `write` receives no `meta`, the bucket MUST synthesize one
  *   with `storedAt: Date.now()` (and any other `TMeta` fields it knows
  *   how to populate).
- * - `clear` MUST remove every entry the adapter manages.
+ * - `clear` MUST remove every entry the bucket manages.
  * - All five methods MAY throw on infrastructure errors. The engine
  *   treats throws as fatal (strict mode).
  */
-export interface IStorageAdapter<TMeta extends IBaseMeta = IBaseMeta> {
+export interface IBucket<TMeta extends IBaseMeta = IBaseMeta> {
   read<T>(key: string): Promise<{ value: T } | undefined>
   write<T>(key: string, value: T, meta?: TMeta): Promise<void>
   meta(key: string): Promise<TMeta | undefined>
@@ -90,21 +90,21 @@ export type Policy =
   | 'stale-while-revalidate'
 
 /**
- * Combined cache options without adapter wiring. Kept exported for
+ * Combined cache options without bucket wiring. Kept exported for
  * backwards-compatible consumer types that mirror the policy shape.
  */
 export type CacheOptions = CacheOptionsBase & PolicyOptions
 
 /**
- * Constructor options for `Cacheables<TMeta>`.
+ * Constructor options for `Cacheable<TMeta>`.
  *
- * `adapters` is required; the array is L1 first. `namespace`, when
- * supplied, is prefixed onto every key passed to adapters as
+ * `buckets` is required; the array is L1 first. `namespace`, when
+ * supplied, is prefixed onto every key passed to buckets as
  * `${namespace}:${key}`.
  */
-export type CacheablesOptions<TMeta extends IBaseMeta = IBaseMeta> =
+export type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> =
   CacheOptionsBase &
     PolicyOptions & {
-      adapters: IStorageAdapter<TMeta>[]
+      buckets: IBucket<TMeta>[]
       namespace?: string
     }

--- a/tests/buckets/memoryBucket.test.ts
+++ b/tests/buckets/memoryBucket.test.ts
@@ -1,8 +1,8 @@
-import { MemoryAdapter } from '../../src'
+import { MemoryBucket } from '../../src'
 
-describe('MemoryAdapter', () => {
+describe('MemoryBucket', () => {
   it('write without meta synthesizes storedAt: Date.now()', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     const before = Date.now()
     await a.write('k', 'v')
     const after = Date.now()
@@ -13,33 +13,33 @@ describe('MemoryAdapter', () => {
   })
 
   it('write with meta persists storedAt verbatim', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     await a.write('k', 'v', { storedAt: 12345 })
     const meta = await a.meta('k')
     expect(meta?.storedAt).toBe(12345)
   })
 
   it('read returns undefined for missing keys', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     expect(await a.read('missing')).toBeUndefined()
     expect(await a.meta('missing')).toBeUndefined()
   })
 
   it('read returns stored value wrapped', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     await a.write('k', { hello: 'world' })
     expect(await a.read('k')).toEqual({ value: { hello: 'world' } })
   })
 
   it('read distinguishes a stored undefined from absence', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     await a.write('k', undefined)
     expect(await a.read('k')).toEqual({ value: undefined })
     expect(await a.read('missing')).toBeUndefined()
   })
 
   it('delete removes only the specified key', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     await a.write('a', 1)
     await a.write('b', 2)
     await a.delete('a')
@@ -48,7 +48,7 @@ describe('MemoryAdapter', () => {
   })
 
   it('clear removes everything', async () => {
-    const a = new MemoryAdapter()
+    const a = new MemoryBucket()
     await a.write('a', 1)
     await a.write('b', 2)
     await a.clear()

--- a/tests/cascade.test.ts
+++ b/tests/cascade.test.ts
@@ -1,5 +1,5 @@
-import { Cacheables } from '../src'
-import type { IBaseMeta, IStorageAdapter } from '../src'
+import { Cacheable } from '../src'
+import type { IBaseMeta, IBucket } from '../src'
 
 interface WriteCall {
   key: string
@@ -7,7 +7,7 @@ interface WriteCall {
   meta: IBaseMeta | undefined
 }
 
-class FakeAdapter implements IStorageAdapter<IBaseMeta> {
+class FakeBucket implements IBucket<IBaseMeta> {
   store = new Map<string, { value: unknown; meta: IBaseMeta }>()
 
   readCalls = 0
@@ -62,9 +62,9 @@ class FakeAdapter implements IStorageAdapter<IBaseMeta> {
 describe('cascade behavior', () => {
   it('L1 hit: does not read L2, probes L2 once, no writes', async () => {
     const seedMeta: IBaseMeta = { storedAt: Date.now() }
-    const l1 = new FakeAdapter({ key: 'k', value: 'v', meta: seedMeta })
-    const l2 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const l1 = new FakeBucket({ key: 'k', value: 'v', meta: seedMeta })
+    const l2 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -81,13 +81,13 @@ describe('cascade behavior', () => {
 
   it('L1 hit + L2 already has it: no writes anywhere', async () => {
     const seedMeta: IBaseMeta = { storedAt: 1000 }
-    const l1 = new FakeAdapter({ key: 'k', value: 'v', meta: seedMeta })
-    const l2 = new FakeAdapter({
+    const l1 = new FakeBucket({ key: 'k', value: 'v', meta: seedMeta })
+    const l2 = new FakeBucket({
       key: 'k',
       value: 'v',
       meta: { storedAt: 999 },
     })
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     await cache.remember(async () => 'fresh', 'k')
 
@@ -97,9 +97,9 @@ describe('cascade behavior', () => {
 
   it('L1 miss + L2 hit: L1 backfilled with L2 meta (storedAt preserved)', async () => {
     const l2Meta: IBaseMeta = { storedAt: 12345 }
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter({ key: 'k', value: 'v2', meta: l2Meta })
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket({ key: 'k', value: 'v2', meta: l2Meta })
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -113,9 +113,9 @@ describe('cascade behavior', () => {
   })
 
   it('Both miss: resource called once; L1 written without meta; L2 written with L1 meta', async () => {
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     const before = Date.now()
     let calls = 0
@@ -147,10 +147,10 @@ describe('cascade behavior', () => {
 
   it('3 layers, L3 hit: L1 and L2 both filled with L3 meta', async () => {
     const l3Meta: IBaseMeta = { storedAt: 42 }
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter()
-    const l3 = new FakeAdapter({ key: 'k', value: 'deep', meta: l3Meta })
-    const cache = new Cacheables({ adapters: [l1, l2, l3] })
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket()
+    const l3 = new FakeBucket({ key: 'k', value: 'deep', meta: l3Meta })
+    const cache = new Cacheable({ buckets: [l1, l2, l3] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -164,18 +164,18 @@ describe('cascade behavior', () => {
 
   it('max-age across layers: stale L1 with fresh L2 returns L2 value', async () => {
     const now = Date.now()
-    const l1 = new FakeAdapter({
+    const l1 = new FakeBucket({
       key: 'k',
       value: 'l1-stale',
       meta: { storedAt: now - 500 },
     })
-    const l2 = new FakeAdapter({
+    const l2 = new FakeBucket({
       key: 'k',
       value: 'l2-fresh',
       meta: { storedAt: now - 50 },
     })
-    const cache = new Cacheables({
-      adapters: [l1, l2],
+    const cache = new Cacheable({
+      buckets: [l1, l2],
       policy: 'max-age',
       maxAge: 100,
     })
@@ -192,18 +192,18 @@ describe('cascade behavior', () => {
 
   it('max-age miss across all layers calls resource', async () => {
     const now = Date.now()
-    const l1 = new FakeAdapter({
+    const l1 = new FakeBucket({
       key: 'k',
       value: 'l1-stale',
       meta: { storedAt: now - 500 },
     })
-    const l2 = new FakeAdapter({
+    const l2 = new FakeBucket({
       key: 'k',
       value: 'l2-stale',
       meta: { storedAt: now - 500 },
     })
-    const cache = new Cacheables({
-      adapters: [l1, l2],
+    const cache = new Cacheable({
+      buckets: [l1, l2],
       policy: 'max-age',
       maxAge: 100,
     })
@@ -218,10 +218,10 @@ describe('cascade behavior', () => {
     expect(calls).toBe(1)
   })
 
-  it('delete propagates to all adapters', async () => {
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1, l2] })
+  it('delete propagates to all buckets', async () => {
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     await cache.remember(async () => 'v', 'k')
     await cache.delete('k')
@@ -230,10 +230,10 @@ describe('cascade behavior', () => {
     expect(l2.deleteCalls).toEqual(['k'])
   })
 
-  it('clear propagates to all adapters', async () => {
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1, l2] })
+  it('clear propagates to all buckets', async () => {
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     await cache.remember(async () => 'v', 'k')
     await cache.clear()
@@ -243,26 +243,26 @@ describe('cascade behavior', () => {
   })
 
   it('isCached returns true if any layer has the key', async () => {
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter({
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket({
       key: 'k',
       value: 'v',
       meta: { storedAt: Date.now() },
     })
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     expect(await cache.isCached('k')).toBe(true)
     expect(await cache.isCached('missing')).toBe(false)
   })
 
   it('meta returns highest-priority layer meta', async () => {
-    const l1 = new FakeAdapter()
-    const l2 = new FakeAdapter({
+    const l1 = new FakeBucket()
+    const l2 = new FakeBucket({
       key: 'k',
       value: 'v',
       meta: { storedAt: 999 },
     })
-    const cache = new Cacheables({ adapters: [l1, l2] })
+    const cache = new Cacheable({ buckets: [l1, l2] })
 
     expect(await cache.meta('k')).toEqual({ storedAt: 999 })
 
@@ -272,8 +272,8 @@ describe('cascade behavior', () => {
   })
 
   it('caches resources that resolve to undefined', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1] })
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1] })
 
     let calls = 0
     const resource = async () => {
@@ -292,9 +292,9 @@ describe('cascade behavior', () => {
   })
 
   it('treats meta-says-yes / read-says-undefined as a miss', async () => {
-    // Simulates a delete that races between #cascadeProbe and adapter.read:
+    // Simulates a delete that races between #cascadeProbe and bucket.read:
     // meta still reports the entry; read claims absence.
-    const l1 = new FakeAdapter({
+    const l1 = new FakeBucket({
       key: 'k',
       value: 'stale',
       meta: { storedAt: Date.now() },
@@ -304,7 +304,7 @@ describe('cascade behavior', () => {
       return undefined
     }
 
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     let calls = 0
     const result = await cache.remember(async () => {
@@ -319,9 +319,9 @@ describe('cascade behavior', () => {
 
 describe('cascade strict error propagation', () => {
   it('rejects when meta() throws', async () => {
-    const l1 = new FakeAdapter()
+    const l1 = new FakeBucket()
     l1.throwOn.meta = true
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     await expect(cache.remember(async () => 'v', 'k')).rejects.toThrow(
       'meta failed',
@@ -329,13 +329,13 @@ describe('cascade strict error propagation', () => {
   })
 
   it('rejects when read() throws on hit', async () => {
-    const l1 = new FakeAdapter({
+    const l1 = new FakeBucket({
       key: 'k',
       value: 'v',
       meta: { storedAt: Date.now() },
     })
     l1.throwOn.read = true
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     await expect(cache.remember(async () => 'fresh', 'k')).rejects.toThrow(
       'read failed',
@@ -343,9 +343,9 @@ describe('cascade strict error propagation', () => {
   })
 
   it('rejects when write() throws on miss', async () => {
-    const l1 = new FakeAdapter()
+    const l1 = new FakeBucket()
     l1.throwOn.write = true
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     await expect(cache.remember(async () => 'fresh', 'k')).rejects.toThrow(
       'write failed',
@@ -353,17 +353,17 @@ describe('cascade strict error propagation', () => {
   })
 
   it('rejects when delete() throws', async () => {
-    const l1 = new FakeAdapter()
+    const l1 = new FakeBucket()
     l1.throwOn.delete = true
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     await expect(cache.delete('k')).rejects.toThrow('delete failed')
   })
 
   it('rejects when clear() throws', async () => {
-    const l1 = new FakeAdapter()
+    const l1 = new FakeBucket()
     l1.throwOn.clear = true
-    const cache = new Cacheables({ adapters: [l1] })
+    const cache = new Cacheable({ buckets: [l1] })
 
     await expect(cache.clear()).rejects.toThrow('clear failed')
   })
@@ -373,8 +373,8 @@ describe('concurrent dedup', () => {
   const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
   it('cache-only: deduplicates concurrent miss callers', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({ adapters: [l1] })
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({ buckets: [l1] })
 
     let calls = 0
     const slow = async () => {
@@ -391,9 +391,9 @@ describe('concurrent dedup', () => {
   })
 
   it('network-only-non-concurrent: deduplicates concurrent callers', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({
-      adapters: [l1],
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({
+      buckets: [l1],
       policy: 'network-only-non-concurrent',
     })
 
@@ -412,9 +412,9 @@ describe('concurrent dedup', () => {
   })
 
   it('max-age: deduplicates concurrent miss callers', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({
-      adapters: [l1],
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({
+      buckets: [l1],
       policy: 'max-age',
       maxAge: 1000,
     })
@@ -434,9 +434,9 @@ describe('concurrent dedup', () => {
   })
 
   it('SWR miss: deduplicates concurrent miss callers', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({
-      adapters: [l1],
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({
+      buckets: [l1],
       policy: 'stale-while-revalidate',
     })
 
@@ -455,9 +455,9 @@ describe('concurrent dedup', () => {
   })
 
   it('network-only: does NOT deduplicate (control)', async () => {
-    const l1 = new FakeAdapter()
-    const cache = new Cacheables({
-      adapters: [l1],
+    const l1 = new FakeBucket()
+    const cache = new Cacheable({
+      buckets: [l1],
       policy: 'network-only',
     })
 

--- a/tests/fetchPolicies.test.ts
+++ b/tests/fetchPolicies.test.ts
@@ -1,4 +1,4 @@
-import { Cacheables, MemoryAdapter } from '../src'
+import { Cacheable, MemoryBucket } from '../src'
 
 const mockedApiRequest = <T>(value: T, duration = 0): Promise<T> =>
   new Promise((resolve) => {
@@ -15,8 +15,8 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('Fetch Policies', () => {
   it('cache-only', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'cache-only',
     })
 
@@ -32,8 +32,8 @@ describe('Fetch Policies', () => {
   })
 
   it('network-only-non-concurrent', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'network-only-non-concurrent',
     })
 
@@ -56,8 +56,8 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 0, 0, 3])
   })
   it('network-only', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'network-only',
     })
 
@@ -75,8 +75,8 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 1, 2])
   })
   it('max-age', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'max-age',
       maxAge: 100,
     })
@@ -94,8 +94,8 @@ describe('Fetch Policies', () => {
     expect([a, b, c, d]).toEqual([0, 0, 2, 2])
   })
   it('stale-while-revalidate', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'stale-while-revalidate',
     })
 
@@ -120,8 +120,8 @@ describe('Fetch Policies', () => {
   })
 
   it('stale-while-revalidate with maxAge', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'stale-while-revalidate',
       maxAge: 200,
     })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { Cacheables, MemoryAdapter } from '../src'
+import { Cacheable, MemoryBucket } from '../src'
 
 const errorMessage = 'This is an error message.'
 
@@ -22,7 +22,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('Cache operations', () => {
   it('Returns correct values', async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
     const value = 10
     const cachedValue = await cache.remember(() => mockedApiRequest(value), 'a')
     expect(await cache.isCached('a')).toEqual(true)
@@ -30,7 +30,7 @@ describe('Cache operations', () => {
   })
 
   it('Stores multiple caches', async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
 
     const valueA = 10
     const valueB = 20
@@ -50,7 +50,7 @@ describe('Cache operations', () => {
   })
 
   it('Deletes values', async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
 
     const value = 10
     await cache.remember(() => mockedApiRequest(value), 'a')
@@ -61,7 +61,7 @@ describe('Cache operations', () => {
   })
 
   it('Clears the cache', async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
 
     const value = 10
     await cache.remember(() => mockedApiRequest(value), 'a')
@@ -72,13 +72,13 @@ describe('Cache operations', () => {
   })
 
   it('Creates proper keys', () => {
-    const key = Cacheables.key('aaa', 'bbb', 'ccc', 'ddd', 10, 20)
+    const key = Cacheable.key('aaa', 'bbb', 'ccc', 'ddd', 10, 20)
     expect(key).toEqual('aaa:bbb:ccc:ddd:10:20')
   })
 
   it('Returns correctly if disabled', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       enabled: false,
     })
 
@@ -94,8 +94,8 @@ describe('Cache operations', () => {
   it('Logs correctly', async () => {
     console.log = jest.fn()
 
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       log: true,
       enabled: false,
     })
@@ -116,9 +116,9 @@ describe('Cache operations', () => {
     expect(console.log).lastCalledWith('Cacheable "a": hits: 2')
   })
 
-  it('Throws when constructed without adapters', () => {
-    expect(() => new Cacheables({ adapters: [] })).toThrow(
-      'At least one storage adapter is required',
+  it('Throws when constructed without buckets', () => {
+    expect(() => new Cacheable({ buckets: [] })).toThrow(
+      'At least one bucket is required',
     )
   })
 
@@ -130,8 +130,8 @@ describe('Cache operations', () => {
    * Assuming the time starts at 0
    */
   it('Handles race conditions correctly', async () => {
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       policy: 'max-age',
       maxAge: 100,
     })
@@ -159,8 +159,8 @@ describe('Cache operations', () => {
   it('Handles multiple calls correctly', async () => {
     console.log = jest.fn()
 
-    const cache = new Cacheables({
-      adapters: [new MemoryAdapter()],
+    const cache = new Cacheable({
+      buckets: [new MemoryBucket()],
       log: true,
       policy: 'max-age',
       maxAge: 100,
@@ -192,7 +192,7 @@ describe('Cache operations', () => {
   })
 
   it("Doesn't interfere with error handling", async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
     const rejecting = () => {
       return cache.remember(() => mockedApiRequest(0, 10, true), 'a')
     }
@@ -200,7 +200,7 @@ describe('Cache operations', () => {
   })
 
   it("Doesn't cache rejected value", async () => {
-    const cache = new Cacheables({ adapters: [new MemoryAdapter()] })
+    const cache = new Cacheable({ buckets: [new MemoryBucket()] })
     let errNo = 1
     const rejecting = () => {
       return cache.remember(() => Promise.reject(errNo++), 'a')

--- a/tests/namespace.test.ts
+++ b/tests/namespace.test.ts
@@ -1,10 +1,10 @@
-import { Cacheables, MemoryAdapter } from '../src'
+import { Cacheable, MemoryBucket } from '../src'
 
 describe('namespace', () => {
-  it('isolates entries between two instances sharing one adapter', async () => {
-    const adapter = new MemoryAdapter()
-    const a = new Cacheables({ adapters: [adapter], namespace: 'a' })
-    const b = new Cacheables({ adapters: [adapter], namespace: 'b' })
+  it('isolates entries between two instances sharing one bucket', async () => {
+    const bucket = new MemoryBucket()
+    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
+    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')
@@ -13,20 +13,20 @@ describe('namespace', () => {
     expect(await b.remember(async () => 'fresh', 'k')).toBe('B')
   })
 
-  it('writes adapter keys with namespace prefix', async () => {
-    const adapter = new MemoryAdapter()
-    const a = new Cacheables({ adapters: [adapter], namespace: 'tenant1' })
+  it('writes bucket keys with namespace prefix', async () => {
+    const bucket = new MemoryBucket()
+    const a = new Cacheable({ buckets: [bucket], namespace: 'tenant1' })
 
     await a.remember(async () => 'v', 'user:42')
 
-    expect(await adapter.read('tenant1:user:42')).toEqual({ value: 'v' })
-    expect(await adapter.read('user:42')).toBeUndefined()
+    expect(await bucket.read('tenant1:user:42')).toEqual({ value: 'v' })
+    expect(await bucket.read('user:42')).toBeUndefined()
   })
 
   it('delete on one namespace does not affect another', async () => {
-    const adapter = new MemoryAdapter()
-    const a = new Cacheables({ adapters: [adapter], namespace: 'a' })
-    const b = new Cacheables({ adapters: [adapter], namespace: 'b' })
+    const bucket = new MemoryBucket()
+    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
+    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')
@@ -37,10 +37,10 @@ describe('namespace', () => {
     expect(await b.isCached('k')).toBe(true)
   })
 
-  it('clear from one namespace wipes shared adapter (documented caveat)', async () => {
-    const adapter = new MemoryAdapter()
-    const a = new Cacheables({ adapters: [adapter], namespace: 'a' })
-    const b = new Cacheables({ adapters: [adapter], namespace: 'b' })
+  it('clear from one namespace wipes shared bucket (documented caveat)', async () => {
+    const bucket = new MemoryBucket()
+    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
+    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')
@@ -52,9 +52,9 @@ describe('namespace', () => {
   })
 
   it('omitting namespace stores keys verbatim', async () => {
-    const adapter = new MemoryAdapter()
-    const cache = new Cacheables({ adapters: [adapter] })
+    const bucket = new MemoryBucket()
+    const cache = new Cacheable({ buckets: [bucket] })
     await cache.remember(async () => 'v', 'k')
-    expect(await adapter.read('k')).toEqual({ value: 'v' })
+    expect(await bucket.read('k')).toEqual({ value: 'v' })
   })
 })


### PR DESCRIPTION
## Summary
- Renames the main class `Cacheables` → `Cacheable`, the `IStorageAdapter` interface → `IBucket`, the `MemoryAdapter` → `MemoryBucket`, and the `adapters` constructor option → `buckets`. The `CacheablesOptions` type becomes `CacheableOptions`.
- Moves `src/adapters/` → `src/buckets/` (and the equivalent test directory); updates the engine internals, error messages, README, and v3 → v4 migration notes.
- Behavior, contract, and policies are unchanged — this is a pure rename to position storage layers as buckets and reserve the singular `Cacheable` name for the cache itself.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run eslint`
- [x] `npm test` (53/53 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)