### PR TITLE
Remove the "enabled" option from Cacheable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ await getWeather() // hit — cached
 type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> = {
   buckets: IBucket<TMeta>[]            // REQUIRED, L1 first
   namespace: string                    // REQUIRED — bucket keys become `${namespace}:${key}`
-  enabled?: boolean                    // default: true
   log?: boolean                        // default: false
   logTiming?: boolean                  // default: false
 } & (
@@ -256,6 +255,7 @@ Breaking changes:
 - `clear()` returns `Promise<void>` (was `void`). Add `await`.
 - `isCached(key)` returns `Promise<boolean>` (was `boolean`). Add `await`.
 - `keys()` is **removed**. Enumerating heterogeneous async layers (some non-enumerable, like CDNs) doesn't have a single sensible semantic.
+- The `enabled` option is **removed**. If you need to bypass caching, call `resource()` directly instead of `cache.remember()`.
 - `Cacheable` is now generic in `TMeta`. Plain `new Cacheable({ buckets, namespace })` defaults to `Cacheable<IBaseMeta>` and is source-compatible at the type level.
 - New constructor options: `buckets` (required) and `namespace` (required).
 - Any throw from any bucket rejects `remember()`. Previously the in-memory store couldn't fail; this is new strict-error surface for users with custom buckets.

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -7,7 +7,6 @@ import type {
 } from './types'
 
 export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
-  enabled: boolean
   log: boolean
   logTiming: boolean
 
@@ -24,7 +23,6 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
     }
     this.#buckets = options.buckets
     this.#namespace = options.namespace
-    this.enabled = options.enabled ?? true
     this.log = options.log ?? false
     this.logTiming = options.logTiming ?? false
     this.#policy = options.policy ?? 'cache-only'
@@ -68,11 +66,6 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
   }
 
   async remember<T>(resource: () => Promise<T>, key: string): Promise<T> {
-    if (!this.enabled) {
-      if (this.log) Logger.logDisabled()
-      return resource()
-    }
-
     const { logTiming, log } = this
     const logId = Logger.getLogId(key)
     if (logTiming) Logger.logTime(logId)

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -13,11 +13,6 @@ export class Logger {
     console.timeEnd(key)
   }
 
-  static logDisabled(): void {
-    // eslint-disable-next-line no-console
-    console.log('CACHE: Caching disabled')
-  }
-
   static logStats(key: string, hits: number): void {
     // eslint-disable-next-line no-console
     console.log(`Cacheable "${key}": hits: ${hits}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,10 +37,6 @@ export interface IBucket<TMeta extends IBaseMeta = IBaseMeta> {
 
 type CacheOptionsBase = {
   /**
-   * Enables caching.
-   */
-  enabled?: boolean
-  /**
    * Enable/disable logging of cache hits.
    */
   log?: boolean

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -76,22 +76,6 @@ describe('Cache operations', () => {
     expect(key).toEqual('aaa:bbb:ccc:ddd:10:20')
   })
 
-  it('Returns correctly if disabled', async () => {
-    const cache = new Cacheable({
-      buckets: [new MemoryBucket()],
-      namespace: 'test',
-      enabled: false,
-    })
-
-    const value = 10
-    const uncachedValue = await cache.remember(
-      () => mockedApiRequest(value),
-      'a',
-    )
-
-    expect(uncachedValue).toEqual(value)
-  })
-
   it('Logs correctly', async () => {
     console.log = jest.fn()
 
@@ -99,14 +83,9 @@ describe('Cache operations', () => {
       buckets: [new MemoryBucket()],
       namespace: 'test',
       log: true,
-      enabled: false,
     })
 
     const cachedRequest = () => cache.remember(() => mockedApiRequest(1), 'a')
-
-    await cachedRequest()
-    expect(console.log).lastCalledWith('CACHE: Caching disabled')
-    cache.enabled = true
 
     await cachedRequest()
     expect(console.log).lastCalledWith('Cacheable "a": hits: 0')


### PR DESCRIPTION
## Summary

- Drops the `enabled` option from `CacheableOptions` along with the matching property on `Cacheable` and the disabled-path branch in `remember()`.
- Removes the now-unused `Logger.logDisabled()` method and its test coverage.
- Documents the removal in the v2 → v3 migration notes — bypassing the cache is now done by calling `resource()` directly.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)