### PR TITLE
Remove isCached from the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ cache.remember(() => fetch('https://some-url.com/api'), 'key')
   - [cache.remember(resource, key)](#cacherememberresource-key-promiset)
   - [cache.delete(key)](#cachedeletekey-promisevoid)
   - [cache.clear()](#cacheclear-promisevoid)
-  - [cache.isCached(key)](#cacheiscachedkey-promiseboolean)
   - [cache.meta(key)](#cachemetakey-promisetmeta--undefined)
   - [Cacheable.key(...args)](#cacheablekeyargs-string)
 - [Buckets](#buckets)
@@ -107,10 +106,6 @@ Deletes the entry from every bucket.
 ### `cache.clear(): Promise<void>`
 
 Clears every bucket and the in-flight registry.
-
-### `cache.isCached(key): Promise<boolean>`
-
-`true` if any layer reports the key (existence-only — does not consider freshness).
 
 ### `cache.meta(key): Promise<TMeta | undefined>`
 
@@ -292,7 +287,7 @@ const tenantA = new Cacheable({ buckets: [bucket], namespace: 'tenant-a' })
 const tenantB = new Cacheable({ buckets: [bucket], namespace: 'tenant-b' })
 ```
 
-Two instances can share a bucket without colliding. `delete` and `isCached` respect the namespace; `clear()` wipes the entire underlying bucket (it has no notion of which keys belong to which namespace), so reach for it only when you really mean _everything_.
+Two instances can share a bucket without colliding. `delete` and `meta` respect the namespace; `clear()` wipes the entire underlying bucket (it has no notion of which keys belong to which namespace), so reach for it only when you really mean _everything_.
 
 ## Cache Policies
 
@@ -355,7 +350,8 @@ Breaking changes:
 - **`namespace` is required.** Every bucket call sees keys prefixed with `${namespace}:`. Pick one even if only one instance writes to the bucket.
 - **`enabled` option removed.** If you need to bypass the cache, call `resource()` directly instead of `cache.remember(...)`.
 - **`keys()` removed.** Enumerating heterogeneous async layers (some non-enumerable, like CDNs) has no single sensible semantic.
-- **`delete`, `clear`, `isCached` are async.** They now return `Promise<void>` / `Promise<boolean>` — add `await`.
+- **`delete` and `clear` are async.** They now return `Promise<void>` — add `await`.
+- **`isCached` removed.** Use `cache.meta(key)` instead — it returns `undefined` when the key is absent and the meta object otherwise.
 - **`log` / `logTiming` replaced by `logger`.** Pass `new ConsoleLogger()` to restore the previous default-on logging, or implement `ILogger` to route messages elsewhere. Timing now ships as a formatted string (`Cacheable "<key>": <Xms>`) instead of `console.time` / `timeEnd`.
 - **Options types reshaped.** v2's `CacheOptions` (constructor) and `CacheableOptions` (per-call) are gone. v3's constructor options type is `CacheableOptions` — same name as v2's per-call type, completely different shape (it now carries `buckets`, `namespace`, `policy`, and `logger`).
 - **Buckets can throw.** Any throw from any bucket rejects `remember()`. v2's in-memory store couldn't fail, so this is a new error surface to be aware of once you wire up a custom bucket.

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -51,12 +51,6 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
     await Promise.all(this.#buckets.map((b) => b.clear()))
   }
 
-  async isCached(key: string): Promise<boolean> {
-    const fullKey = this.#fullKey(key)
-    const probes = await this.#cascadeProbe(fullKey)
-    return probes.some((m) => m !== undefined)
-  }
-
   async meta(key: string): Promise<TMeta | undefined> {
     const fullKey = this.#fullKey(key)
     const probes = await this.#cascadeProbe(fullKey)

--- a/tests/cascade.test.ts
+++ b/tests/cascade.test.ts
@@ -244,19 +244,6 @@ describe('cascade behavior', () => {
     expect(l2.clearCalls).toBe(1)
   })
 
-  it('isCached returns true if any layer has the key', async () => {
-    const l1 = new FakeBucket()
-    const l2 = new FakeBucket({
-      key: 'test:k',
-      value: 'v',
-      meta: { storedAt: Date.now() },
-    })
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
-
-    expect(await cache.isCached('k')).toBe(true)
-    expect(await cache.isCached('missing')).toBe(false)
-  })
-
   it('meta returns highest-priority layer meta', async () => {
     const l1 = new FakeBucket()
     const l2 = new FakeBucket({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -28,7 +28,7 @@ describe('Cache operations', () => {
     })
     const value = 10
     const cachedValue = await cache.remember(() => mockedApiRequest(value), 'a')
-    expect(await cache.isCached('a')).toEqual(true)
+    expect(await cache.meta('a')).toBeDefined()
     expect(cachedValue).toEqual(value)
   })
 
@@ -50,8 +50,8 @@ describe('Cache operations', () => {
       'b',
     )
 
-    expect(await cache.isCached('a')).toEqual(true)
-    expect(await cache.isCached('b')).toEqual(true)
+    expect(await cache.meta('a')).toBeDefined()
+    expect(await cache.meta('b')).toBeDefined()
     expect([cachedValueA, cachedValueB]).toEqual([valueA, valueB])
   })
 
@@ -64,9 +64,9 @@ describe('Cache operations', () => {
     const value = 10
     await cache.remember(() => mockedApiRequest(value), 'a')
 
-    expect(await cache.isCached('a')).toEqual(true)
+    expect(await cache.meta('a')).toBeDefined()
     await cache.delete('a')
-    expect(await cache.isCached('a')).toEqual(false)
+    expect(await cache.meta('a')).toBeUndefined()
   })
 
   it('Clears the cache', async () => {
@@ -78,9 +78,9 @@ describe('Cache operations', () => {
     const value = 10
     await cache.remember(() => mockedApiRequest(value), 'a')
 
-    expect(await cache.isCached('a')).toEqual(true)
+    expect(await cache.meta('a')).toBeDefined()
     await cache.clear()
-    expect(await cache.isCached('a')).toEqual(false)
+    expect(await cache.meta('a')).toBeUndefined()
   })
 
   it('Creates proper keys', () => {

--- a/tests/namespace.test.ts
+++ b/tests/namespace.test.ts
@@ -33,8 +33,8 @@ describe('namespace', () => {
 
     await a.delete('k')
 
-    expect(await a.isCached('k')).toBe(false)
-    expect(await b.isCached('k')).toBe(true)
+    expect(await a.meta('k')).toBeUndefined()
+    expect(await b.meta('k')).toBeDefined()
   })
 
   it('clear from one namespace wipes shared bucket (documented caveat)', async () => {
@@ -47,7 +47,7 @@ describe('namespace', () => {
 
     await a.clear()
 
-    expect(await a.isCached('k')).toBe(false)
-    expect(await b.isCached('k')).toBe(false)
+    expect(await a.meta('k')).toBeUndefined()
+    expect(await b.meta('k')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Drop `Cacheable#isCached`; `cache.meta(key)` already covers the existence-check use case (returns `undefined` when no layer has the key) and exposes the meta as a bonus.
- Migrate tests from `isCached(...)` to `meta(...)` defined/undefined assertions, and delete the now-redundant cascade test that only re-exercised the probe path.
- Update README: remove the API section and TOC entry, switch the namespacing prose to mention `meta`, and split the v2 → v3 migration bullet so `isCached` is called out as **removed** with a pointer to `meta(key)`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (50/50 pass)
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)