### PR TITLE
Make namespace a positional argument to the Cacheable constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A small, typed cache with composable storage buckets and a handful of cache poli
 ```ts
 import { Cacheable, MemoryBucket } from 'cacheables'
 
-const cache = new Cacheable({ buckets: [new MemoryBucket()], namespace: 'app' })
+const cache = new Cacheable('app', { buckets: [new MemoryBucket()] })
 
 cache.remember(() => fetch('https://some-url.com/api'), 'key')
 ```
@@ -26,7 +26,7 @@ cache.remember(() => fetch('https://some-url.com/api'), 'key')
 - [Installation](#installation)
 - [Usage](#usage)
 - [API](#api)
-  - [new Cacheable(options)](#new-cacheableoptions-cacheabletmeta)
+  - [new Cacheable(namespace, options)](#new-cacheablenamespace-options-cacheabletmeta)
   - [cache.remember(resource, key)](#cacherememberresource-key-promiset)
   - [cache.delete(key)](#cachedeletekey-promisevoid)
   - [cache.clear()](#cacheclear-promisevoid)
@@ -60,9 +60,8 @@ import { Cacheable, MemoryBucket } from 'cacheables'
 
 const apiUrl = 'https://goweather.herokuapp.com/weather/Karlsruhe'
 
-const cache = new Cacheable({
+const cache = new Cacheable('weather', {
   buckets: [new MemoryBucket()],
-  namespace: 'weather',
   policy: 'max-age',
   maxAge: 5_000,
 })
@@ -77,12 +76,16 @@ await getWeather() // hit — cached
 
 ## API
 
-### `new Cacheable(options): Cacheable<TMeta>`
+### `new Cacheable(namespace, options): Cacheable<TMeta>`
 
 ```ts
+new Cacheable<TMeta extends IBaseMeta = IBaseMeta>(
+  namespace: string,
+  options: CacheableOptions<TMeta>,
+)
+
 type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> = {
   buckets: IBucket<TMeta>[] // REQUIRED, L1 first
-  namespace: string // REQUIRED — bucket keys become `${namespace}:${key}`
   logger?: ILogger // default: undefined (no logging)
 } & (
   | { policy?: 'cache-only' } // default
@@ -93,7 +96,7 @@ type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> = {
 )
 ```
 
-`buckets` must be a non-empty array; the constructor throws `Error('At least one bucket is required')` otherwise. The first bucket is L1 (fastest, queried first); the rest form deeper layers.
+`namespace` is prefixed onto every key passed to buckets as `${namespace}:${key}`, isolating instances that share a bucket. `buckets` must be a non-empty array; the constructor throws `Error('At least one bucket is required')` otherwise. The first bucket is L1 (fastest, queried first); the rest form deeper layers.
 
 ### `cache.remember(resource, key): Promise<T>`
 
@@ -155,7 +158,7 @@ Ships with the package; covers the common in-memory use case.
 ```ts
 import { Cacheable, MemoryBucket } from 'cacheables'
 
-const cache = new Cacheable({ buckets: [new MemoryBucket()], namespace: 'app' })
+const cache = new Cacheable('app', { buckets: [new MemoryBucket()] })
 ```
 
 ### Writing your own bucket
@@ -187,9 +190,8 @@ class FileSystemBucket implements IBucket {
 ### Cascade behavior
 
 ```ts
-const cache = new Cacheable({
+const cache = new Cacheable('app', {
   buckets: [new MemoryBucket(), new FileSystemBucket()],
-  namespace: 'app',
   policy: 'max-age',
   maxAge: 60_000,
 })
@@ -214,9 +216,8 @@ class ETagBucket implements IBucket<ETagMeta> {
   // read / write / meta / delete / clear …
 }
 
-const cache = new Cacheable<ETagMeta>({
+const cache = new Cacheable<ETagMeta>('app', {
   buckets: [new ETagBucket()],
-  namespace: 'app',
 })
 
 const meta = await cache.meta('user:42') // typed as ETagMeta | undefined
@@ -250,9 +251,8 @@ Forwards each message to `console.log`. Useful as a default during development.
 ```ts
 import { Cacheable, ConsoleLogger, MemoryBucket } from 'cacheables'
 
-const cache = new Cacheable({
+const cache = new Cacheable('app', {
   buckets: [new MemoryBucket()],
-  namespace: 'app',
   logger: new ConsoleLogger(),
 })
 ```
@@ -268,9 +268,8 @@ import { Cacheable, MemoryBucket, type ILogger } from 'cacheables'
 const pinoLogger = pino()
 const logger: ILogger = { log: (m) => pinoLogger.info(m) }
 
-const cache = new Cacheable({
+const cache = new Cacheable('app', {
   buckets: [new MemoryBucket()],
-  namespace: 'app',
   logger,
 })
 ```
@@ -279,12 +278,12 @@ The `logger` field on a `Cacheable` instance is mutable — assign a new logger 
 
 ## Namespacing
 
-`namespace` is required: every bucket call sees keys prefixed with `${namespace}:`. This isolates instances that share the same bucket, so you must pick a namespace at construction time even when only one instance uses a bucket.
+`namespace` is required and is the constructor's first positional argument: every bucket call sees keys prefixed with `${namespace}:`. This isolates instances that share the same bucket, so you must pick a namespace at construction time even when only one instance uses a bucket.
 
 ```ts
 const bucket = new MemoryBucket()
-const tenantA = new Cacheable({ buckets: [bucket], namespace: 'tenant-a' })
-const tenantB = new Cacheable({ buckets: [bucket], namespace: 'tenant-b' })
+const tenantA = new Cacheable('tenant-a', { buckets: [bucket] })
+const tenantB = new Cacheable('tenant-b', { buckets: [bucket] })
 ```
 
 Two instances can share a bucket without colliding. `delete` and `meta` respect the namespace; `clear()` wipes the entire underlying bucket (it has no notion of which keys belong to which namespace), so reach for it only when you really mean _everything_.
@@ -300,9 +299,8 @@ Two instances can share a bucket without colliding. `delete` and `meta` respect 
 | `stale-while-revalidate`      | Return the cached value immediately; if `maxAge` is unset or exceeded, fire a background revalidation. |
 
 ```ts
-new Cacheable({
+new Cacheable('app', {
   buckets: [new MemoryBucket()],
-  namespace: 'app',
   policy: 'max-age',
   maxAge: 1_000,
 })
@@ -330,9 +328,8 @@ await cache.cacheable(() => fetch(url), 'weather', {
 // v3
 import { Cacheable, MemoryBucket, ConsoleLogger } from 'cacheables'
 
-const cache = new Cacheable({
+const cache = new Cacheable('weather', {
   buckets: [new MemoryBucket()],
-  namespace: 'weather',
   policy: 'max-age',
   maxAge: 5_000,
   logger: new ConsoleLogger(),
@@ -345,21 +342,21 @@ Breaking changes:
 
 - **Class renamed** `Cacheables` → `Cacheable`. Update imports and `new Cacheables(...)` call sites. The static helper moves with it: `Cacheables.key(...)` → `Cacheable.key(...)` (behaviour unchanged).
 - **Method renamed** `cache.cacheable(...)` → `cache.remember(...)`.
-- **Cache policy moved to the constructor.** v2 took `cachePolicy` and `maxAge` as a per-call third argument; v3 has no per-call options. Pass `policy` (and `maxAge` where required) once on `new Cacheable({ ... })`. The field is `policy`, not `cachePolicy`. A single instance now serves a single policy — split into multiple instances if you previously mixed policies on one cache.
-- **`buckets` is required** (replaces v2's implicit in-memory store). `new Cacheable()` no longer compiles. `new Cacheable({ buckets: [new MemoryBucket()], namespace: 'app' })` reproduces the v2 default.
-- **`namespace` is required.** Every bucket call sees keys prefixed with `${namespace}:`. Pick one even if only one instance writes to the bucket.
+- **Cache policy moved to the constructor.** v2 took `cachePolicy` and `maxAge` as a per-call third argument; v3 has no per-call options. Pass `policy` (and `maxAge` where required) once on `new Cacheable(namespace, { ... })`. The field is `policy`, not `cachePolicy`. A single instance now serves a single policy — split into multiple instances if you previously mixed policies on one cache.
+- **`buckets` is required** (replaces v2's implicit in-memory store). `new Cacheable()` no longer compiles. `new Cacheable('app', { buckets: [new MemoryBucket()] })` reproduces the v2 default.
+- **`namespace` is required and positional.** It's the constructor's first argument, prefixed onto every bucket key as `${namespace}:`. Pick one even if only one instance writes to the bucket.
 - **`enabled` option removed.** If you need to bypass the cache, call `resource()` directly instead of `cache.remember(...)`.
 - **`keys()` removed.** Enumerating heterogeneous async layers (some non-enumerable, like CDNs) has no single sensible semantic.
 - **`delete` and `clear` are async.** They now return `Promise<void>` — add `await`.
 - **`isCached` removed.** Use `cache.meta(key)` instead — it returns `undefined` when the key is absent and the meta object otherwise.
 - **`log` / `logTiming` replaced by `logger`.** Pass `new ConsoleLogger()` to restore the previous default-on logging, or implement `ILogger` to route messages elsewhere. Timing now ships as a formatted string (`Cacheable "<key>": <Xms>`) instead of `console.time` / `timeEnd`.
-- **Options types reshaped.** v2's `CacheOptions` (constructor) and `CacheableOptions` (per-call) are gone. v3's constructor options type is `CacheableOptions` — same name as v2's per-call type, completely different shape (it now carries `buckets`, `namespace`, `policy`, and `logger`).
+- **Options types reshaped.** v2's `CacheOptions` (constructor) and `CacheableOptions` (per-call) are gone. v3's constructor options type is `CacheableOptions` — same name as v2's per-call type, completely different shape (it now carries `buckets`, `policy`, and `logger`; `namespace` is the constructor's first positional argument).
 - **Buckets can throw.** Any throw from any bucket rejects `remember()`. v2's in-memory store couldn't fail, so this is a new error surface to be aware of once you wire up a custom bucket.
 
 What's new:
 
 - **Multilayer storage.** Pass several buckets to compose tiers (e.g. `[memory, filesystem]`); reads cascade L1 → Ln and back-fill missing layers on every hit.
-- **Typed sidecar metadata.** `Cacheable<TMeta>` is generic; bucket implementations can persist fields like `etag` or `ttl` and `cache.meta(key)` returns them typed. Plain `new Cacheable({ buckets, namespace })` defaults to `Cacheable<IBaseMeta>` and needs no type changes.
+- **Typed sidecar metadata.** `Cacheable<TMeta>` is generic; bucket implementations can persist fields like `etag` or `ttl` and `cache.meta(key)` returns them typed. Plain `new Cacheable(namespace, { buckets })` defaults to `Cacheable<IBaseMeta>` and needs no type changes.
 
 ## License
 

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -16,12 +16,12 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
   #inflight = new Map<string, Promise<unknown>>()
   #hits = new Map<string, number>()
 
-  constructor(options: CacheableOptions<TMeta>) {
+  constructor(namespace: string, options: CacheableOptions<TMeta>) {
     if (!options.buckets || options.buckets.length === 0) {
       throw new Error('At least one bucket is required')
     }
     this.#buckets = options.buckets
-    this.#namespace = options.namespace
+    this.#namespace = namespace
     this.logger = options.logger
     this.#policy = options.policy ?? 'cache-only'
     this.#maxAge =

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,15 +100,13 @@ export type Policy =
 export type CacheOptions = CacheOptionsBase & PolicyOptions
 
 /**
- * Constructor options for `Cacheable<TMeta>`.
+ * Constructor options for `Cacheable<TMeta>`. The namespace is passed
+ * as a positional argument; this bag carries everything else.
  *
- * `buckets` is required; the array is L1 first. `namespace` is
- * required and is prefixed onto every key passed to buckets as
- * `${namespace}:${key}`, isolating instances that share a bucket.
+ * `buckets` is required; the array is L1 first.
  */
 export type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> =
   CacheOptionsBase &
     PolicyOptions & {
       buckets: IBucket<TMeta>[]
-      namespace: string
     }

--- a/tests/cascade.test.ts
+++ b/tests/cascade.test.ts
@@ -64,7 +64,7 @@ describe('cascade behavior', () => {
     const seedMeta: IBaseMeta = { storedAt: Date.now() }
     const l1 = new FakeBucket({ key: 'test:k', value: 'v', meta: seedMeta })
     const l2 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -87,7 +87,7 @@ describe('cascade behavior', () => {
       value: 'v',
       meta: { storedAt: 999 },
     })
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     await cache.remember(async () => 'fresh', 'k')
 
@@ -99,7 +99,7 @@ describe('cascade behavior', () => {
     const l2Meta: IBaseMeta = { storedAt: 12345 }
     const l1 = new FakeBucket()
     const l2 = new FakeBucket({ key: 'test:k', value: 'v2', meta: l2Meta })
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -115,7 +115,7 @@ describe('cascade behavior', () => {
   it('Both miss: resource called once; L1 written without meta; L2 written with L1 meta', async () => {
     const l1 = new FakeBucket()
     const l2 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     const before = Date.now()
     let calls = 0
@@ -150,7 +150,7 @@ describe('cascade behavior', () => {
     const l1 = new FakeBucket()
     const l2 = new FakeBucket()
     const l3 = new FakeBucket({ key: 'test:k', value: 'deep', meta: l3Meta })
-    const cache = new Cacheable({ buckets: [l1, l2, l3], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2, l3] })
 
     const result = await cache.remember(async () => 'fresh', 'k')
 
@@ -174,9 +174,8 @@ describe('cascade behavior', () => {
       value: 'l2-fresh',
       meta: { storedAt: now - 50 },
     })
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1, l2],
-      namespace: 'test',
       policy: 'max-age',
       maxAge: 100,
     })
@@ -203,9 +202,8 @@ describe('cascade behavior', () => {
       value: 'l2-stale',
       meta: { storedAt: now - 500 },
     })
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1, l2],
-      namespace: 'test',
       policy: 'max-age',
       maxAge: 100,
     })
@@ -223,7 +221,7 @@ describe('cascade behavior', () => {
   it('delete propagates to all buckets', async () => {
     const l1 = new FakeBucket()
     const l2 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     await cache.remember(async () => 'v', 'k')
     await cache.delete('k')
@@ -235,7 +233,7 @@ describe('cascade behavior', () => {
   it('clear propagates to all buckets', async () => {
     const l1 = new FakeBucket()
     const l2 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     await cache.remember(async () => 'v', 'k')
     await cache.clear()
@@ -251,7 +249,7 @@ describe('cascade behavior', () => {
       value: 'v',
       meta: { storedAt: 999 },
     })
-    const cache = new Cacheable({ buckets: [l1, l2], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1, l2] })
 
     expect(await cache.meta('k')).toEqual({ storedAt: 999 })
 
@@ -262,7 +260,7 @@ describe('cascade behavior', () => {
 
   it('caches resources that resolve to undefined', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     let calls = 0
     const resource = async () => {
@@ -293,7 +291,7 @@ describe('cascade behavior', () => {
       return undefined
     }
 
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     let calls = 0
     const result = await cache.remember(async () => {
@@ -310,7 +308,7 @@ describe('cascade strict error propagation', () => {
   it('rejects when meta() throws', async () => {
     const l1 = new FakeBucket()
     l1.throwOn.meta = true
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     await expect(cache.remember(async () => 'v', 'k')).rejects.toThrow(
       'meta failed',
@@ -324,7 +322,7 @@ describe('cascade strict error propagation', () => {
       meta: { storedAt: Date.now() },
     })
     l1.throwOn.read = true
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     await expect(cache.remember(async () => 'fresh', 'k')).rejects.toThrow(
       'read failed',
@@ -334,7 +332,7 @@ describe('cascade strict error propagation', () => {
   it('rejects when write() throws on miss', async () => {
     const l1 = new FakeBucket()
     l1.throwOn.write = true
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     await expect(cache.remember(async () => 'fresh', 'k')).rejects.toThrow(
       'write failed',
@@ -344,7 +342,7 @@ describe('cascade strict error propagation', () => {
   it('rejects when delete() throws', async () => {
     const l1 = new FakeBucket()
     l1.throwOn.delete = true
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     await expect(cache.delete('k')).rejects.toThrow('delete failed')
   })
@@ -352,7 +350,7 @@ describe('cascade strict error propagation', () => {
   it('rejects when clear() throws', async () => {
     const l1 = new FakeBucket()
     l1.throwOn.clear = true
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     await expect(cache.clear()).rejects.toThrow('clear failed')
   })
@@ -363,7 +361,7 @@ describe('concurrent dedup', () => {
 
   it('cache-only: deduplicates concurrent miss callers', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({ buckets: [l1], namespace: 'test' })
+    const cache = new Cacheable('test', { buckets: [l1] })
 
     let calls = 0
     const slow = async () => {
@@ -381,9 +379,8 @@ describe('concurrent dedup', () => {
 
   it('network-only-non-concurrent: deduplicates concurrent callers', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1],
-      namespace: 'test',
       policy: 'network-only-non-concurrent',
     })
 
@@ -403,9 +400,8 @@ describe('concurrent dedup', () => {
 
   it('max-age: deduplicates concurrent miss callers', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1],
-      namespace: 'test',
       policy: 'max-age',
       maxAge: 1000,
     })
@@ -426,9 +422,8 @@ describe('concurrent dedup', () => {
 
   it('SWR miss: deduplicates concurrent miss callers', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1],
-      namespace: 'test',
       policy: 'stale-while-revalidate',
     })
 
@@ -448,9 +443,8 @@ describe('concurrent dedup', () => {
 
   it('network-only: does NOT deduplicate (control)', async () => {
     const l1 = new FakeBucket()
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [l1],
-      namespace: 'test',
       policy: 'network-only',
     })
 

--- a/tests/fetchPolicies.test.ts
+++ b/tests/fetchPolicies.test.ts
@@ -15,9 +15,8 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('Fetch Policies', () => {
   it('cache-only', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'cache-only',
     })
 
@@ -33,9 +32,8 @@ describe('Fetch Policies', () => {
   })
 
   it('network-only-non-concurrent', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'network-only-non-concurrent',
     })
 
@@ -58,9 +56,8 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 0, 0, 3])
   })
   it('network-only', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'network-only',
     })
 
@@ -78,9 +75,8 @@ describe('Fetch Policies', () => {
     expect(values).toEqual([0, 1, 2])
   })
   it('max-age', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'max-age',
       maxAge: 100,
     })
@@ -99,9 +95,8 @@ describe('Fetch Policies', () => {
     expect([a, b, c, d]).toEqual([0, 0, 2, 2])
   })
   it('stale-while-revalidate', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'stale-while-revalidate',
     })
 
@@ -126,9 +121,8 @@ describe('Fetch Policies', () => {
   })
 
   it('stale-while-revalidate with maxAge', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'stale-while-revalidate',
       maxAge: 200,
     })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -22,9 +22,8 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('Cache operations', () => {
   it('Returns correct values', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
     const value = 10
     const cachedValue = await cache.remember(() => mockedApiRequest(value), 'a')
@@ -33,9 +32,8 @@ describe('Cache operations', () => {
   })
 
   it('Stores multiple caches', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
 
     const valueA = 10
@@ -56,9 +54,8 @@ describe('Cache operations', () => {
   })
 
   it('Deletes values', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
 
     const value = 10
@@ -70,9 +67,8 @@ describe('Cache operations', () => {
   })
 
   it('Clears the cache', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
 
     const value = 10
@@ -91,9 +87,8 @@ describe('Cache operations', () => {
   it('Logs correctly', async () => {
     console.log = jest.fn()
 
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       logger: new ConsoleLogger(),
     })
 
@@ -110,7 +105,7 @@ describe('Cache operations', () => {
   })
 
   it('Throws when constructed without buckets', () => {
-    expect(() => new Cacheable({ buckets: [], namespace: 'test' })).toThrow(
+    expect(() => new Cacheable('test', { buckets: [] })).toThrow(
       'At least one bucket is required',
     )
   })
@@ -123,9 +118,8 @@ describe('Cache operations', () => {
    * Assuming the time starts at 0
    */
   it('Handles race conditions correctly', async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       policy: 'max-age',
       maxAge: 100,
     })
@@ -153,9 +147,8 @@ describe('Cache operations', () => {
   it('Handles multiple calls correctly', async () => {
     console.log = jest.fn()
 
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
       logger: new ConsoleLogger(),
       policy: 'max-age',
       maxAge: 100,
@@ -187,9 +180,8 @@ describe('Cache operations', () => {
   })
 
   it("Doesn't interfere with error handling", async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
     const rejecting = () => {
       return cache.remember(() => mockedApiRequest(0, 10, true), 'a')
@@ -198,9 +190,8 @@ describe('Cache operations', () => {
   })
 
   it("Doesn't cache rejected value", async () => {
-    const cache = new Cacheable({
+    const cache = new Cacheable('test', {
       buckets: [new MemoryBucket()],
-      namespace: 'test',
     })
     let errNo = 1
     const rejecting = () => {

--- a/tests/namespace.test.ts
+++ b/tests/namespace.test.ts
@@ -3,8 +3,8 @@ import { Cacheable, MemoryBucket } from '../src'
 describe('namespace', () => {
   it('isolates entries between two instances sharing one bucket', async () => {
     const bucket = new MemoryBucket()
-    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
-    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
+    const a = new Cacheable('a', { buckets: [bucket] })
+    const b = new Cacheable('b', { buckets: [bucket] })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')
@@ -15,7 +15,7 @@ describe('namespace', () => {
 
   it('writes bucket keys with namespace prefix', async () => {
     const bucket = new MemoryBucket()
-    const a = new Cacheable({ buckets: [bucket], namespace: 'tenant1' })
+    const a = new Cacheable('tenant1', { buckets: [bucket] })
 
     await a.remember(async () => 'v', 'user:42')
 
@@ -25,8 +25,8 @@ describe('namespace', () => {
 
   it('delete on one namespace does not affect another', async () => {
     const bucket = new MemoryBucket()
-    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
-    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
+    const a = new Cacheable('a', { buckets: [bucket] })
+    const b = new Cacheable('b', { buckets: [bucket] })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')
@@ -39,8 +39,8 @@ describe('namespace', () => {
 
   it('clear from one namespace wipes shared bucket (documented caveat)', async () => {
     const bucket = new MemoryBucket()
-    const a = new Cacheable({ buckets: [bucket], namespace: 'a' })
-    const b = new Cacheable({ buckets: [bucket], namespace: 'b' })
+    const a = new Cacheable('a', { buckets: [bucket] })
+    const b = new Cacheable('b', { buckets: [bucket] })
 
     await a.remember(async () => 'A', 'k')
     await b.remember(async () => 'B', 'k')


### PR DESCRIPTION
## Summary

- The `Cacheable` constructor signature changes from `new Cacheable(options)` to `new Cacheable(namespace, options)`.
- `namespace` is removed from `CacheableOptions`; `buckets`, `policy`, `maxAge`, and `logger` stay in the bag (the discriminated union that ties `maxAge` to its policies is preserved).
- All 50 tests, README examples, API doc, and the v2→v3 migration notes are updated to the new shape.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` (50 passing)
- [x] \`npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)