### PR TITLE
Merge timing and hit-count logs into one HIT/MISS line per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ interface ILogger {
 }
 ```
 
-When a `logger` is configured, every `cache.remember(...)` call emits two messages — timing, then hit count:
+When a `logger` is configured, every `cache.remember(...)` call emits one message tagged `HIT` or `MISS` with the elapsed time:
 
 ```
-Cacheable "weather": 12ms
-Cacheable "weather": hits: 1
+Cacheable "weather": MISS 12ms
+Cacheable "weather": HIT 0.2ms
 ```
 
 ### Built-in `ConsoleLogger`
@@ -349,7 +349,7 @@ Breaking changes:
 - **`keys()` removed.** Enumerating heterogeneous async layers (some non-enumerable, like CDNs) has no single sensible semantic.
 - **`delete` and `clear` are async.** They now return `Promise<void>` — add `await`.
 - **`isCached` removed.** Use `cache.meta(key)` instead — it returns `undefined` when the key is absent and the meta object otherwise.
-- **`log` / `logTiming` replaced by `logger`.** Pass `new ConsoleLogger()` to restore the previous default-on logging, or implement `ILogger` to route messages elsewhere. Timing now ships as a formatted string (`Cacheable "<key>": <Xms>`) instead of `console.time` / `timeEnd`.
+- **`log` / `logTiming` replaced by `logger`.** Pass `new ConsoleLogger()` to restore the previous default-on logging, or implement `ILogger` to route messages elsewhere. Each `remember()` call emits a single formatted message (`Cacheable "<key>": HIT|MISS <Xms>`) instead of `console.time` / `timeEnd`.
 - **Options types reshaped.** v2's `CacheOptions` (constructor) and `CacheableOptions` (per-call) are gone. v3's constructor options type is `CacheableOptions` — same name as v2's per-call type, completely different shape (it now carries `buckets`, `policy`, and `logger`; `namespace` is the constructor's first positional argument).
 - **Buckets can throw.** Any throw from any bucket rejects `remember()`. v2's in-memory store couldn't fail, so this is a new error surface to be aware of once you wire up a custom bucket.
 

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -14,7 +14,6 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
   #buckets: IBucket<TMeta>[]
   #namespace: string
   #inflight = new Map<string, Promise<unknown>>()
-  #hits = new Map<string, number>()
 
   constructor(namespace: string, options: CacheableOptions<TMeta>) {
     if (!options.buckets || options.buckets.length === 0) {
@@ -41,13 +40,11 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
 
   async delete(key: string): Promise<void> {
     const fullKey = this.#fullKey(key)
-    this.#hits.delete(fullKey)
     await Promise.all(this.#buckets.map((b) => b.delete(fullKey)))
   }
 
   async clear(): Promise<void> {
     this.#inflight.clear()
-    this.#hits.clear()
     await Promise.all(this.#buckets.map((b) => b.clear()))
   }
 
@@ -59,21 +56,14 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
 
   async remember<T>(resource: () => Promise<T>, key: string): Promise<T> {
     const { logger } = this
-    const start = logger ? Date.now() : 0
+    const start = logger ? performance.now() : 0
 
     const fullKey = this.#fullKey(key)
     const { value, hit } = await this.#runPolicy<T>(resource, fullKey)
 
-    if (hit) {
-      const next = (this.#hits.get(fullKey) ?? 0) + 1
-      this.#hits.set(fullKey, next)
-    } else if (!this.#hits.has(fullKey)) {
-      this.#hits.set(fullKey, 0)
-    }
-
     if (logger) {
-      logger.log(`Cacheable "${key}": ${Date.now() - start}ms`)
-      logger.log(`Cacheable "${key}": hits: ${this.#hits.get(fullKey) ?? 0}`)
+      const elapsed = Math.round((performance.now() - start) * 10) / 10
+      logger.log(`Cacheable "${key}": ${hit ? 'HIT' : 'MISS'} ${elapsed}ms`)
     }
 
     return value

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -95,13 +95,19 @@ describe('Cache operations', () => {
     const cachedRequest = () => cache.remember(() => mockedApiRequest(1), 'a')
 
     await cachedRequest()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 0')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": MISS \d+(\.\d+)?ms$/),
+    )
 
     await cachedRequest()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 1')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": HIT \d+(\.\d+)?ms$/),
+    )
 
     await cachedRequest()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 2')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": HIT \d+(\.\d+)?ms$/),
+    )
   })
 
   it('Throws when constructed without buckets', () => {
@@ -160,23 +166,31 @@ describe('Cache operations', () => {
 
     // This should be a miss and take ~10ms
     await hitCache()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 0')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": MISS \d+(\.\d+)?ms$/),
+    )
 
     // This should be a hit and take ~0ms
     await hitCache()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 1')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": HIT \d+(\.\d+)?ms$/),
+    )
 
     await wait(60)
 
     // This should be a hit and take ~0ms
     await hitCache()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 2')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": HIT \d+(\.\d+)?ms$/),
+    )
 
     await wait(60)
 
     // This should be a miss and take ~10ms
     await hitCache()
-    expect(console.log).lastCalledWith('Cacheable "a": hits: 2')
+    expect(console.log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "a": MISS \d+(\.\d+)?ms$/),
+    )
   })
 
   it("Doesn't interfere with error handling", async () => {


### PR DESCRIPTION
## Summary
- `cache.remember(...)` now emits a single log line per call: `Cacheable "<key>": HIT|MISS <Xms>` (e.g. `Cacheable "weather": MISS 12ms`, `Cacheable "weather": HIT 0.2ms`), replacing the previous timing + hit-count pair.
- Switched timing from `Date.now()` to `performance.now()` rounded to one decimal so fast hits report sub-millisecond durations.
- Removed the per-key `#hits` counter (its only consumer was the dropped log line) and updated the README logger section, v3 migration note, and tests accordingly.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)