### PR TITLE
Add cache.resolve(producer, key) returning bucket meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cache.remember(() => fetch('https://some-url.com/api'), 'key')
 - [API](#api)
   - [new Cacheable(namespace, options)](#new-cacheablenamespace-options-cacheabletmeta)
   - [cache.remember(resource, key)](#cacherememberresource-key-promiset)
+  - [cache.resolve(resource, key)](#cacheresolveresource-key-promisetmeta)
   - [cache.delete(key) / cache.clear()](#cachedeletekey-promisevoid--cacheclear-promisevoid)
   - [cache.meta(key)](#cachemetakey-promisetmeta--undefined)
   - [Cacheable.key(...args)](#cacheablekeyargs-string)
@@ -101,13 +102,34 @@ type CacheableOptions<TMeta extends IBaseMeta = IBaseMeta> = {
 
 Resolves to the cached value if present (subject to policy); otherwise calls `resource()` and writes to every bucket.
 
+### `cache.resolve(resource, key): Promise<TMeta>`
+
+Same fresh-or-fetch behavior as `remember`, but returns the bucket's meta instead of the producer's value. Useful when the projection a bucket exposes through `TMeta` is what callers actually need — for example, a filesystem bucket that fetches and stores a remote image as bytes, then exposes a local URL on its meta:
+
+```ts
+interface FilesystemMeta extends IBaseMeta {
+  url: string
+}
+
+const cache = new Cacheable<FilesystemMeta>('images', {
+  buckets: [new FilesystemBucket()],
+})
+
+const { url } = await cache.resolve(
+  () => fetch(imageUrl).then((r) => r.arrayBuffer()),
+  imageUrl,
+)
+```
+
+`resolve` and `remember` share the same in-flight registry: a concurrent pair against the same key triggers `resource()` once and both observers see the same `storedAt`. Unlike `cache.meta(key)`, `resolve` honors the cache policy — a stale entry will trigger a producer call (or a background revalidation under `stale-while-revalidate`).
+
 ### `cache.delete(key): Promise<void>` / `cache.clear(): Promise<void>`
 
 `delete` removes the entry from every bucket. `clear` wipes every bucket and the in-flight registry. Both are async — `await` them.
 
 ### `cache.meta(key): Promise<TMeta | undefined>`
 
-Returns the meta from the highest-priority layer that has the key, or `undefined` if no layer has it. Useful to inspect sidecar fields (`etag`, `ttl`, …) and to test for presence.
+Returns the meta from the highest-priority layer that has the key, or `undefined` if no layer has it. **Bypasses the policy** — it returns whatever the cache holds, fresh or stale. Reach for `cache.resolve(...)` instead when you want a meta that has been refreshed against the policy; reach for `cache.meta(key)` for raw inspection (debugging, eviction logic, presence checks).
 
 ### `Cacheable.key(...args): string`
 
@@ -220,10 +242,10 @@ Every bucket passed to the constructor must satisfy `IBucket<ETagMeta>`, enforce
 
 ## Cache Policies
 
-The policy is set once on the constructor and applies to every `remember()` call on that instance. Two mechanics matter across policies:
+The policy is set once on the constructor and applies to every `remember()` and `resolve()` call on that instance. Two mechanics matter across policies:
 
 - **Freshness**: whether a cached value qualifies for return without re-fetching. Only `max-age` and `stale-while-revalidate` look at `storedAt`.
-- **In-flight deduplication**: when two callers ask for the same key concurrently, an instance keeps a per-key promise so only one `resource()` runs and both callers receive its result. Dedup is policy-dependent (see each section below).
+- **In-flight deduplication**: when two callers ask for the same key concurrently, an instance keeps a per-key promise so only one `resource()` runs and both callers receive its result. `remember` and `resolve` share that registry — a concurrent pair against the same key triggers one `resource()` call. Dedup is policy-dependent (see each section below).
 
 | Policy                                                        | Returns cached value                 | Calls `resource()`                               | In-flight dedup |
 | ------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------ | --------------- |
@@ -361,7 +383,7 @@ interface ILogger {
 }
 ```
 
-Every `cache.remember(...)` emits one message, tagged `HIT` or `MISS` with the elapsed time:
+Every `cache.remember(...)` and `cache.resolve(...)` emits one message, tagged `HIT` or `MISS` with the elapsed time:
 
 ```
 Cacheable "weather": MISS 12ms

--- a/src/Cacheable.ts
+++ b/src/Cacheable.ts
@@ -69,30 +69,46 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
     return value
   }
 
+  async resolve<T>(resource: () => Promise<T>, key: string): Promise<TMeta> {
+    const { logger } = this
+    const start = logger ? performance.now() : 0
+
+    const fullKey = this.#fullKey(key)
+    const { meta, hit } = await this.#runPolicy<T>(resource, fullKey)
+
+    if (logger) {
+      const elapsed = Math.round((performance.now() - start) * 10) / 10
+      logger.log(`Cacheable "${key}": ${hit ? 'HIT' : 'MISS'} ${elapsed}ms`)
+    }
+
+    return meta
+  }
+
   async #runPolicy<T>(
     resource: () => Promise<T>,
     fullKey: string,
-  ): Promise<{ value: T; hit: boolean }> {
+  ): Promise<{ value: T; hit: boolean; meta: TMeta }> {
     switch (this.#policy) {
       case 'cache-only': {
         return this.#dedup(fullKey, async () => {
           const cached = await this.#cascadeRead<T>(fullKey)
-          if (cached) return { value: cached.value, hit: true }
+          if (cached)
+            return { value: cached.value, hit: true, meta: cached.meta }
           const value = await resource()
-          await this.#cascadeWrite(fullKey, value)
-          return { value, hit: false }
+          const meta = await this.#cascadeWrite(fullKey, value)
+          return { value, hit: false, meta }
         })
       }
       case 'network-only': {
         const value = await resource()
-        await this.#cascadeWrite(fullKey, value)
-        return { value, hit: false }
+        const meta = await this.#cascadeWrite(fullKey, value)
+        return { value, hit: false, meta }
       }
       case 'network-only-non-concurrent': {
         return this.#dedup(fullKey, async () => {
           const value = await resource()
-          await this.#cascadeWrite(fullKey, value)
-          return { value, hit: false }
+          const meta = await this.#cascadeWrite(fullKey, value)
+          return { value, hit: false, meta }
         })
       }
       case 'max-age': {
@@ -102,10 +118,11 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
             fullKey,
             (m) => Date.now() - m.storedAt <= maxAge,
           )
-          if (cached) return { value: cached.value, hit: true }
+          if (cached)
+            return { value: cached.value, hit: true, meta: cached.meta }
           const value = await resource()
-          await this.#cascadeWrite(fullKey, value)
-          return { value, hit: false }
+          const meta = await this.#cascadeWrite(fullKey, value)
+          return { value, hit: false, meta }
         })
       }
       case 'stale-while-revalidate': {
@@ -117,24 +134,24 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
           Date.now() - cached.meta.storedAt > maxAge
 
         if (cached && !isStale) {
-          return { value: cached.value, hit: true }
+          return { value: cached.value, hit: true, meta: cached.meta }
         }
 
         if (cached && isStale) {
           this.#dedup(fullKey, async () => {
             const value = await resource()
-            await this.#cascadeWrite(fullKey, value)
-            return { value, hit: false }
+            const meta = await this.#cascadeWrite(fullKey, value)
+            return { value, hit: false, meta }
           }).catch(() => {
             /* swallow background revalidation errors */
           })
-          return { value: cached.value, hit: true }
+          return { value: cached.value, hit: true, meta: cached.meta }
         }
 
         return this.#dedup(fullKey, async () => {
           const value = await resource()
-          await this.#cascadeWrite(fullKey, value)
-          return { value, hit: false }
+          const meta = await this.#cascadeWrite(fullKey, value)
+          return { value, hit: false, meta }
         })
       }
     }
@@ -190,15 +207,19 @@ export class Cacheable<TMeta extends IBaseMeta = IBaseMeta> {
     if (writes.length > 0) await Promise.all(writes)
   }
 
-  async #cascadeWrite<T>(fullKey: string, value: T): Promise<void> {
+  async #cascadeWrite<T>(fullKey: string, value: T): Promise<TMeta> {
     const [l1, ...rest] = this.#buckets
-    if (l1 === undefined) return
+    if (l1 === undefined) {
+      throw new Error('At least one bucket is required')
+    }
     await l1.write(fullKey, value)
-    if (rest.length === 0) return
     const meta = await l1.meta(fullKey)
     if (meta === undefined) {
       throw new Error('L1 bucket did not persist meta after write')
     }
-    await Promise.all(rest.map((b) => b.write(fullKey, value, meta)))
+    if (rest.length > 0) {
+      await Promise.all(rest.map((b) => b.write(fullKey, value, meta)))
+    }
+    return meta
   }
 }

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,0 +1,190 @@
+import { Cacheable, MemoryBucket } from '../src'
+import type { IBaseMeta, IBucket } from '../src'
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('resolve', () => {
+  it('cache-only: hit returns cached meta; miss writes fresh meta', async () => {
+    const cache = new Cacheable('test', { buckets: [new MemoryBucket()] })
+
+    const before = Date.now()
+    const a = await cache.resolve(async () => 'v', 'k')
+    const after = Date.now()
+
+    expect(a.storedAt).toBeGreaterThanOrEqual(before)
+    expect(a.storedAt).toBeLessThanOrEqual(after)
+
+    await wait(10)
+    const b = await cache.resolve(async () => 'v2', 'k')
+    expect(b.storedAt).toBe(a.storedAt)
+  })
+
+  it('network-only: every call writes fresh meta', async () => {
+    const cache = new Cacheable('test', {
+      buckets: [new MemoryBucket()],
+      policy: 'network-only',
+    })
+
+    const a = await cache.resolve(async () => 'v', 'k')
+    await wait(10)
+    const b = await cache.resolve(async () => 'v', 'k')
+    expect(b.storedAt).toBeGreaterThan(a.storedAt)
+  })
+
+  it('network-only-non-concurrent: every serial call writes fresh meta', async () => {
+    const cache = new Cacheable('test', {
+      buckets: [new MemoryBucket()],
+      policy: 'network-only-non-concurrent',
+    })
+
+    const a = await cache.resolve(async () => 'v', 'k')
+    await wait(10)
+    const b = await cache.resolve(async () => 'v', 'k')
+    expect(b.storedAt).toBeGreaterThan(a.storedAt)
+  })
+
+  it('max-age: meta is stable within window, refreshes when expired', async () => {
+    const cache = new Cacheable('test', {
+      buckets: [new MemoryBucket()],
+      policy: 'max-age',
+      maxAge: 100,
+    })
+
+    const a = await cache.resolve(async () => 'v', 'k')
+    const b = await cache.resolve(async () => 'v', 'k')
+    expect(b.storedAt).toBe(a.storedAt)
+
+    await wait(200)
+    const c = await cache.resolve(async () => 'v', 'k')
+    expect(c.storedAt).toBeGreaterThan(a.storedAt)
+  })
+
+  it('SWR: returns stale meta immediately, background revalidation updates it', async () => {
+    const cache = new Cacheable('test', {
+      buckets: [new MemoryBucket()],
+      policy: 'stale-while-revalidate',
+      maxAge: 50,
+    })
+
+    const a = await cache.resolve(async () => 'v', 'k')
+    await wait(150)
+
+    // Stale: returns cached meta immediately and kicks off a background refetch.
+    const b = await cache.resolve(async () => 'v', 'k')
+    expect(b.storedAt).toBe(a.storedAt)
+
+    // Give the background refetch plenty of time to land.
+    await wait(150)
+
+    const c = await cache.resolve(async () => 'v', 'k')
+    expect(c.storedAt).toBeGreaterThan(a.storedAt)
+  })
+
+  it('concurrent remember + resolve share one producer call and one storedAt', async () => {
+    const cache = new Cacheable('test', { buckets: [new MemoryBucket()] })
+
+    let calls = 0
+    const slow = async () => {
+      calls += 1
+      await wait(20)
+      return 'v'
+    }
+
+    const [value, meta] = await Promise.all([
+      cache.remember(slow, 'k'),
+      cache.resolve(slow, 'k'),
+    ])
+
+    expect(calls).toBe(1)
+    expect(value).toBe('v')
+
+    const peeked = await cache.meta('k')
+    expect(peeked?.storedAt).toBe(meta.storedAt)
+  })
+
+  it('resolve-returned meta matches cache.meta on fresh entries', async () => {
+    const cache = new Cacheable('test', { buckets: [new MemoryBucket()] })
+    const meta = await cache.resolve(async () => 'v', 'k')
+    const peeked = await cache.meta('k')
+    expect(peeked).toEqual(meta)
+  })
+
+  it('logs HIT/MISS with elapsed time, same shape as remember', async () => {
+    const log = jest.fn()
+    const cache = new Cacheable('test', {
+      buckets: [new MemoryBucket()],
+      logger: { log },
+    })
+
+    await cache.resolve(async () => 'v', 'k')
+    expect(log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "k": MISS \d+(\.\d+)?ms$/),
+    )
+
+    await cache.resolve(async () => 'v', 'k')
+    expect(log).lastCalledWith(
+      expect.stringMatching(/^Cacheable "k": HIT \d+(\.\d+)?ms$/),
+    )
+  })
+
+  describe('cascade', () => {
+    interface WriteCall {
+      key: string
+      value: unknown
+      meta: IBaseMeta | undefined
+    }
+
+    class FakeBucket implements IBucket<IBaseMeta> {
+      store = new Map<string, { value: unknown; meta: IBaseMeta }>()
+      writeCalls: WriteCall[] = []
+
+      constructor(seed?: { key: string; value: unknown; meta: IBaseMeta }) {
+        if (seed)
+          this.store.set(seed.key, { value: seed.value, meta: seed.meta })
+      }
+
+      async read<T>(key: string): Promise<{ value: T } | undefined> {
+        const entry = this.store.get(key)
+        return entry === undefined ? undefined : { value: entry.value as T }
+      }
+
+      async write<T>(key: string, value: T, meta?: IBaseMeta): Promise<void> {
+        this.writeCalls.push({ key, value, meta })
+        this.store.set(key, { value, meta: meta ?? { storedAt: Date.now() } })
+      }
+
+      async meta(key: string): Promise<IBaseMeta | undefined> {
+        return this.store.get(key)?.meta
+      }
+
+      async delete(key: string): Promise<void> {
+        this.store.delete(key)
+      }
+
+      async clear(): Promise<void> {
+        this.store.clear()
+      }
+    }
+
+    it('L1 miss + L2 hit: resolve returns the L2 meta (storedAt preserved)', async () => {
+      const l2Meta: IBaseMeta = { storedAt: 12345 }
+      const l1 = new FakeBucket()
+      const l2 = new FakeBucket({ key: 'test:k', value: 'v', meta: l2Meta })
+      const cache = new Cacheable('test', { buckets: [l1, l2] })
+
+      const meta = await cache.resolve(async () => 'fresh', 'k')
+      expect(meta.storedAt).toBe(12345)
+    })
+
+    it('both miss: resolve returns L1 meta after write; storedAt agrees with what L2 received', async () => {
+      const l1 = new FakeBucket()
+      const l2 = new FakeBucket()
+      const cache = new Cacheable('test', { buckets: [l1, l2] })
+
+      const meta = await cache.resolve(async () => 'fresh', 'k')
+
+      expect(l2.writeCalls.length).toBe(1)
+      expect(l2.writeCalls[0]!.meta?.storedAt).toBe(meta.storedAt)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `cache.resolve<T>(producer, key): Promise<TMeta>` — same policy and dedup pipeline as `remember`, but returns the bucket's meta instead of the producer's value. Designed for buckets that project derived data through `TMeta` (e.g. a filesystem bucket that stores bytes and exposes a local URL on its meta), so callers stay on a freshness-aware path instead of falling back to the policy-bypassing `cache.meta(key)`.
- Internals: `#runPolicy` now returns `{ value, hit, meta }` and `#cascadeWrite` returns the L1 meta on every miss path (single-bucket and multi-bucket alike); `remember` and `resolve` are thin wrappers that pick `value` or `meta` from the same call.
- README documents `resolve` next to `remember`, sharpens `cache.meta(key)` to flag its policy-bypassing behavior, and updates the Cache Policies and Logger sections to mention `resolve` alongside `remember`.

## Test plan

- [x] `npx jest` — 60 tests pass, including 10 new `tests/resolve.test.ts` cases (all five policies × hit/miss meta semantics, SWR background revalidation updating meta on a subsequent call, concurrent `remember` + `resolve` sharing one producer call and one `storedAt`, agreement with `cache.meta` on fresh entries, cascade tests for L1-miss/L2-hit and both-miss meta forwarding, and HIT/MISS log formatting)
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/**/*.ts`
- [x] `npx prettier --check .`