### PR TITLE
Build before publishing in the release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Summary
The release workflow's `publish-npm` job ran `npm ci && npm publish` with no build step. With `dist/` gitignored and no `prepack`/`prepublishOnly` hook in `package.json`, the published tarball — whose `files` list points at `dist` — would be effectively empty. This adds an explicit `npm run build` between install and publish.

## Test plan
- [ ] Next release produces a tarball that contains the built `dist/` output (verifiable via `npm pack --dry-run` on the release commit, or by inspecting the published artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)