### PR TITLE
Trim verbose Response-body comments from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ import { Cacheable, MemoryBucket } from 'cacheables'
 
 const cache = new Cacheable('app', { buckets: [new MemoryBucket()] })
 
-// Cache the parsed JSON, not the Response — a Response body can be
-// consumed exactly once, so caching the Response itself would break
-// every call after the first .json().
-const data = await cache.remember(
-  () => fetch('https://some-url.com/api').then((r) => r.json()),
-  'key',
-)
+const data = await cache.remember(() => fetchData(), 'key')
 ```
 
 - [Installation](#installation)
@@ -71,8 +65,6 @@ const cache = new Cacheable('weather-data', {
 
 // `remember` is both getter and setter: on a miss it calls the resource
 // and writes to every bucket; on a hit it returns the cached value.
-// Cache the parsed JSON rather than the Response object — the Response
-// body can only be read once.
 const getWeather = () =>
   cache.remember(() => fetch(apiUrl).then((r) => r.json()), 'karlsruhe')
 


### PR DESCRIPTION
## Summary
- Drop the multi-line Response-body caveat from the quick-start snippet and replace it with a one-liner using a generic `fetchData()` call.
- Remove the duplicate Response-body comment from the later `getWeather` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)